### PR TITLE
Fix typo in reference link for 18.11 References

### DIFF
--- a/blueprint/src/chapter/prime_counting_function.tex
+++ b/blueprint/src/chapter/prime_counting_function.tex
@@ -82,5 +82,5 @@ For further reading and more detailed proofs, consult:
 \begin{itemize}
     \item Dusart, P. (2010). Estimates of some functions over primes without Riemann Hypothesis.
     \item Wikipedia page on the Prime Counting Function: \url{https://en.wikipedia.org/wiki/Prime-counting_function}
-    \item TME-EMT Article on Prime Counting Function: \url{https://tmeemt.github.io/Chest/Article/Art01.html}
+    \item TME-EMT Article on Prime Counting Function: \url{https://tmeemt.github.io/Chest/Articles/Art01.html}
 \end{itemize}


### PR DESCRIPTION
Hi. I found out https://tmeemt.github.io/Chest/Article/Art01.html from 18.11 References is broken. Did a quick google search and it seems 's' is missing from the link. The correct link seems to be: https://tmeemt.github.io/Chest/Articles/Art01.html