### PR TITLE
Fix mathematical typos and correct table label placements

### DIFF
--- a/blueprint/src/chapter/beta.tex
+++ b/blueprint/src/chapter/beta.tex
@@ -154,7 +154,7 @@ Let $\beta_k(\alpha) = \alpha + (1 - k\alpha)/(2^k - 2)$ and
 \[
 \alpha_k = \frac{2^k}{(k - 1)2^k + 2}.
 \]
-Via a routine computation, $\beta_{k + 1}(\alpha) \le \beta_k(\alpha)$ for $\alpha \ge \alpha_k$ and any $k \ge 2$. Thus, to verify that $\beta(\alpha) \le \beta_k(\alpha)$ for $0 \le \alpha \le 1/2$, it suffices to just show that the same result holds for $0 \le \alpha \le \alpha_{k}$. However, for $0 \le \alpha \le \alpha_k$ and $k \ge 2$, we have
+Via a routine computation, $\beta_k(\alpha) \le \beta_{k+1}(\alpha)$ for $\alpha \ge \alpha_k$ and any $k \ge 2$. Thus, to verify that $\beta(\alpha) \le \beta_k(\alpha)$ for $0 \le \alpha \le 1/2$, it suffices to just show that the same result holds for $0 \le \alpha \le \alpha_{k}$. However, for $0 \le \alpha \le \alpha_k$ and $k \ge 2$, we have
 \[
 0 \le \alpha \le \alpha_k \le \frac{2^{k + 1}}{(k - 3)2^k + 8}
 \]
@@ -300,6 +300,7 @@ $$ \beta(\alpha) \leq \max\left(\alpha + \frac{1-4\alpha}{14}, \frac{5}{6} \alph
 
 \begin{table}[ht]
     \caption{Huxley table 17.1.}
+    \label{huxley-table-1}
     \centering
     \renewcommand{\arraystretch}{1.2}
     \begin{tabular}{|c|c|c|}
@@ -339,10 +340,11 @@ $$ \beta(\alpha) \leq \max\left(\alpha + \frac{1-4\alpha}{14}, \frac{5}{6} \alph
     $\frac{13+253\alpha}{318}$ & $\frac{2848}{12173} =0.2339\dots$ & $\frac{161}{646} = 0.2492\dots$ \\
     \hline
     \end{tabular}
-    \end{table}\label{huxley-table-1}
+    \end{table}
 
     \begin{table}[ht]
         \caption{Huxley table 19.2.}
+        \label{huxley-table-2}
         \centering
         \renewcommand{\arraystretch}{1.2}
         \begin{tabular}{|c|c|c|}
@@ -370,7 +372,7 @@ $$ \beta(\alpha) \leq \max\left(\alpha + \frac{1-4\alpha}{14}, \frac{5}{6} \alph
         $\frac{29+173\alpha}{280}$ & $\frac{227}{601}=0.3777\dots$ & $\frac{12}{31} = 0.3870\dots$ \\
         \hline
         \end{tabular}
-\end{table}\label{huxley-table-2}
+\end{table}
 
 
 % Area, Lattice points and Exponential sums

--- a/blueprint/src/chapter/beta.tex
+++ b/blueprint/src/chapter/beta.tex
@@ -117,7 +117,7 @@ Applying \cite[(2.54)]{ivic} with $H := T^h$, as well as the ensuing computation
 $$ T^{2\beta(\alpha)+o(1)} \ll N^2 H^{-1} + H^2 + N H^{-1} \sum_{T/N^2 \ll j \ll H} |\sum_{n \in I \cap I-j} e(T (F((n+j)/N) - F(n/N)))|$$
 and hence by the pigeonhole principle
 $$ T^{2\beta(\alpha)+o(1)} \ll N^2 H^{-1} + H^2 + T^{o(1)} N H^{-1} \sum_{j = T^{h'+o(1)}} |\sum_{n \in I \cap I-h} e(T (F((n+j)/N) - F(n/N)))|$$
-for some $2\alpha-1 \leq h' \leq h$ (one can delete this term if $h < 2\alpha-1$).  One can verify that $-\frac{1}{\sigma} \frac{N}{j} (F(u+j/N)-F(u))$ is a model phase function.  Thus, by Definition \ref{beta-def}, one has
+for some $2\alpha-1 \leq h' \leq h$ (one can delete this term if $h < 2\alpha-1$).  One can verify that $-\frac{1}{\sigma} \frac{N}{j} (F(u+j/N)-F(u/N))$ is a model phase function.  Thus, by Definition \ref{beta-def}, one has
 $$ \sum_{n \in I \cap I-h} e(T (F((n+j)/N) - F(n/N))) \ll (T^{1+h'+o(1)}/N)^{\beta(\alpha/(h'+1-\alpha))+o(1)},$$
 and the claim follows after evaluating all terms as powers of $T$.
 \end{proof}

--- a/blueprint/src/chapter/exponent_pairs.tex
+++ b/blueprint/src/chapter/exponent_pairs.tex
@@ -43,7 +43,7 @@ Thus exponent pairs are dual to the convex hull of the graph of $\beta$.  But $\
 
 \begin{proof}  If (i) holds, then for any $0 < \alpha < 1$, any unbounded $T \geq 1$, any $N = T^{\alpha+o(1)}$, interval $I \subset [N,2N]$, and model phase function $F$, we have from (i) that
 $$ \sum_{n \in I} e(T F(n/N)) \ll (T/N)^{k+o(1)} N^{\ell+o(1)} = T^{k + (\ell-k)\alpha + o(1)}.$$
-From Definition \ref{beta-def} we conclude that $\beta(\alpha) \leq k + (\ell-k) \alpha$.  Also since $(k,\ell)$ lies in \eqref{exp-pair-triangle}, we see from \eqref{beta-0}, \eqref{beta-1} that we also have $\beta(\alpha) \leq k + (\ell-k) \alpha$ for $\alpha=0,1$.
+From Definition \ref{beta-def} we conclude that $\beta(\alpha) \leq k + (\ell-k) \alpha$.  Also since $(k,\ell)$ lies in ~\eqref{exp-pair-triangle}, we see from \eqref{beta-0}, \eqref{beta-1} that we also have $\beta(\alpha) \leq k + (\ell-k) \alpha$ for $\alpha=0,1$.
 
 Now suppose that (ii) holds.  Let $F, T, N, I$ be as in Definition \ref{exp-pair-def}.  By underspill it suffices to show that
 $$ \sum_{n \in I} e(T F(n/N)) \ll (T/N)^{k+\eps+o(1)} N^{\ell+\eps+o(1)}$$

--- a/blueprint/src/chapter/exponent_pairs.tex
+++ b/blueprint/src/chapter/exponent_pairs.tex
@@ -43,7 +43,7 @@ Thus exponent pairs are dual to the convex hull of the graph of $\beta$.  But $\
 
 \begin{proof}  If (i) holds, then for any $0 < \alpha < 1$, any unbounded $T \geq 1$, any $N = T^{\alpha+o(1)}$, interval $I \subset [N,2N]$, and model phase function $F$, we have from (i) that
 $$ \sum_{n \in I} e(T F(n/N)) \ll (T/N)^{k+o(1)} N^{\ell+o(1)} = T^{k + (\ell-k)\alpha + o(1)}.$$
-From Definition \ref{beta-def} we conclude that $\beta(\alpha) \leq k + (\ell-k) \alpha$.  Also since $(k,\ell)$ lies in ~\eqref{exp-pair-triangle}, we see from \eqref{beta-0}, \eqref{beta-1} that we also have $\beta(\alpha) \leq k + (\ell-k) \alpha$ for $\alpha=0,1$.
+From Definition \ref{beta-def} we conclude that $\beta(\alpha) \leq k + (\ell-k) \alpha$.  Also since $(k,\ell)$ lies in \eqref{exp-pair-triangle}, we see from \eqref{beta-0}, \eqref{beta-1} that we also have $\beta(\alpha) \leq k + (\ell-k) \alpha$ for $\alpha=0,1$.
 
 Now suppose that (ii) holds.  Let $F, T, N, I$ be as in Definition \ref{exp-pair-def}.  By underspill it suffices to show that
 $$ \sum_{n \in I} e(T F(n/N)) \ll (T/N)^{k+\eps+o(1)} N^{\ell+\eps+o(1)}$$


### PR DESCRIPTION
Hi,

This pull request addresses a few issues in the blueprint and source files:

1. **Mathematical Typos Fixed (`beta.tex`):**
   * Corrected $F(u)$ to $F(u/N)$ to maintain consistency in the phase function argument.
   * Fixed the inequality direction between successive $\beta_k$ computations to read $\beta_k(\alpha) \le \beta_{k+1}(\alpha)$.

2. **Hyperlink & Layout Fixes (`exponent_pairs.tex`):**
   * Corrected the placement of table `\label` commands by moving them inside the `\end{table}` environment, which resolves the broken hyperref links and counter mismatches on the web version.

Best regards,
Fatima
