### PR TITLE
fix: move mu-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/zeta_growth.tex
+++ b/blueprint/src/chapter/zeta_growth.tex
@@ -138,6 +138,7 @@ for large $T$, giving the claim.
 
 \begin{table}[ht]
 \caption{Historical bounds on $\mu(\sigma)$ for $1/2 \le \sigma \le 1$, and the exponent pair generating them (if applicable).}
+\label{mu-table}
 \centering
 \renewcommand{\arraystretch}{1.2}
 \begin{tabular}{|c|c|c|}
@@ -187,7 +188,7 @@ Heath-Brown (2017) \cite{heathbrown_new_2017} & $\mu(\sigma) \le \frac{8}{63}\sq
 Heath-Brown (2020) \cite{demeter_small_2020} & $\mu(11/15) \leq 1/15$& \\
 \hline
 \end{tabular}
-\end{table}\label{mu-table}
+\end{table}
 
 \literature
 \code{add_literature_bounds_mu()}


### PR DESCRIPTION
## Summary
Moves `\label{mu-table}` from after `\end{table}` to immediately after the caption.

## Bug
Theorem `mu-hist` cites `Table \ref{mu-table}`, but the label was placed after `\end{table}`, which breaks hyperref counter assignment on the web blueprint (same failure mode as the Huxley tables fixed in #146).

## Root cause
LaTeX/hyperref expects `\label` inside the floating environment; a trailing `\end{table}\label{…}` attaches the label to the wrong anchor.

## Why this fix is correct
Matches the label placement correction already merged for the Huxley tables in `beta.tex` (#146).

## Test plan
- [ ] Blueprint build succeeds
- [ ] `\ref{mu-table}` in the zeta growth chapter links to the historical bounds table on the web site

Made with [Cursor](https://cursor.com)