### PR TITLE
fix: move best-mu-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/zeta_growth.tex
+++ b/blueprint/src/chapter/zeta_growth.tex
@@ -240,6 +240,7 @@ The new exponent pairs in \Cref{new-exp-pair} may be used to obtain sharper boun
 
 \begin{table}[ht]
 \caption{Current sharpest known bound on $\mu(\sigma)$ for $1/2 \le \sigma \le 1$}
+\label{best-mu-table}
 \centering
 \renewcommand{\arraystretch}{2.2}
 \begin{tabular}{|c|c|c|}
@@ -269,7 +270,7 @@ $\mu(\sigma) \leq \dfrac{29}{130} - \dfrac{3}{13}\sigma$ & $\dfrac{7441}{8695}\l
 \begin{tabular}{@{}c@{}}
 $\mu(\sigma) \leq \lambda\mu_n + (1 - \lambda)\mu_{n + 1}$ \\ $\mu_n = \dfrac{2}{(n - 1)^2(n + 2)}$ \\ $\lambda = (\sigma_{n + 1} - \sigma)/(\sigma_{n + 1} - \sigma_n)$ \end{tabular} & \begin{tabular}{@{}c@{}}$\sigma_n \leq \sigma \leq \sigma_{n + 1}$\\ $\sigma_n = 1 - \dfrac{3 n^2 - 3 n + 2}{n(n - 1)^2(n + 2)},\quad (n \ge 7)$\end{tabular} & \Cref{hb_mu_bounds} \\
 \hline
-\end{tabular}\label{best-mu-table}
+\end{tabular}
 \end{table}
 Derived in \texttt{derived.py} as: \texttt{compute\_best\_mu\_bound()}.
 


### PR DESCRIPTION
## Summary
Moves `\label{best-mu-table}` from after `\end{tabular}` to immediately after the caption.

## Bug
The zeta growth chapter cites `\Cref{best-mu-table}`, but the label sat on the tabular rather than inside the floating table environment.

## Root cause
LaTeX/hyperref expects `\label` inside the `table` float; a trailing `\end{tabular}\label{…}` attaches the anchor incorrectly on the web blueprint (same failure mode as #146 and #156).

## Why this fix is correct
Matches the label placement already used for `mu-table` in this chapter and for the Huxley tables in `beta.tex`.

## Test plan
- [ ] Blueprint build succeeds
- [ ] `\Cref{best-mu-table}` links to the sharpest-bounds table on the web site


Made with [Cursor](https://cursor.com)