### PR TITLE
fix: move gapaa-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/primes.tex
+++ b/blueprint/src/chapter/primes.tex
@@ -126,6 +126,7 @@ Bounds on $\GAPAA$ are recorded in Table \ref{gapaa-table}.
 
 \begin{table}[ht]
     \caption{Historical upper bounds on $\GAPAA$.}
+    \label{gapaa-table}
     \centering
     \renewcommand{\arraystretch}{1.2}
     \begin{tabular}{|c|c|}
@@ -163,7 +164,7 @@ Bounds on $\GAPAA$ are recorded in Table \ref{gapaa-table}.
     R. Li (2025) \cite{li_primes_almost_II_2025} & $\frac{1}{22} = 0.0455\dots$ \\
     \hline
     \end{tabular}
-    \end{table}\label{gapaa-table}
+    \end{table}
 
     Historical bounds on $\GAPSQUARE$ are recorded in Table \ref{gapsquare-table}.
 


### PR DESCRIPTION
## Summary
- `\label{gapaa-table}` was after `\end{table}`, breaking hyperref links (same issue as #146 for exponent_pairs and #156 for mu-table).

## Root cause
LaTeX table counters and `\ref{gapaa-table}` resolve incorrectly when the label sits outside the environment.

## Fix
Place `\label{gapaa-table}` after the caption, before `\begin{tabular}`.

## Test plan
- [ ] Blueprint build / web page cross-ref to gapaa-table works


Made with [Cursor](https://cursor.com)