### PR TITLE
fix: move gapmax-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/primes.tex
+++ b/blueprint/src/chapter/primes.tex
@@ -83,6 +83,7 @@ Historical bounds on $\GAPMAX$ are summarized in the following table:
 
 \begin{table}[ht]
     \caption{Historical upper bounds on $\GAPMAX$.}
+    \label{gapmax-table}
     \centering
     \renewcommand{\arraystretch}{1.2}
     \begin{tabular}{|c|c|}
@@ -120,7 +121,7 @@ Historical bounds on $\GAPMAX$ are summarized in the following table:
     R. Li (2025) \cite{li_number_2025} & $\frac{13}{25} = 0.52$\\
     \hline
     \end{tabular}
-    \end{table}\label{gapmax-table}
+    \end{table}
 
 Bounds on $\GAPAA$ are recorded in Table \ref{gapaa-table}.
 


### PR DESCRIPTION
## Summary
- `\label{gapmax-table}` was placed after `\end{table}` instead of inside the environment.

## Root cause
Same hyperref/counter mismatch fixed in #146 and #156 for other tables in the blueprint.

## Fix
Move label to immediately after `\caption{...}`.

## Test plan
- [ ] `\ref{gapmax-table}` resolves on the web blueprint


Made with [Cursor](https://cursor.com)