### PR TITLE
fix: move gapsquare-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/primes.tex
+++ b/blueprint/src/chapter/primes.tex
@@ -171,6 +171,7 @@ Bounds on $\GAPAA$ are recorded in Table \ref{gapaa-table}.
 
     \begin{table}[ht]
         \caption{Historical upper bounds on $\GAPSQUARE$.}
+        \label{gapsquare-table}
         \centering
         \renewcommand{\arraystretch}{1.2}
         \begin{tabular}{|c|c|}
@@ -194,7 +195,7 @@ Bounds on $\GAPAA$ are recorded in Table \ref{gapaa-table}.
         Stadlmann (2022) \cite{stadlmann_mean_2022} & $\frac{123}{100} = 1.23$ \\
         \hline
     \end{tabular}
-    \end{table}\label{gapsquare-table}
+    \end{table}
 
 The following general bound on $\GAPSQUARE$ is known:
 


### PR DESCRIPTION
## Summary
- `\label{gapsquare-table}` was placed after `\end{table}` instead of inside the environment.

## Root cause
LaTeX/hyperref only associates a `\label` with the current counter when it is inside the floating environment. With the label after `\end{table}`, `\ref{gapsquare-table}` (used on line 170 of `primes.tex`) does not point at the GAPSQUARE bounds table — same failure mode as #146 and #159–#160.

## Fix
Move the label to immediately after `\caption{...}`.

## Test plan
- [ ] `\ref{gapsquare-table}` resolves on the web blueprint


Made with [Cursor](https://cursor.com)