### PR TITLE
fix: move gaplarge-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/primes.tex
+++ b/blueprint/src/chapter/primes.tex
@@ -246,6 +246,7 @@ The proofs are routine and are omitted.  Historical bounds on $\GAPLARGE$ are re
 
 \begin{table}[ht]
     \caption{Historical upper bounds on $\GAPLARGE$ and $\GAPLARGEEQ$.}
+    \label{gaplarge-table}
     \centering
     \renewcommand{\arraystretch}{1.2}
     \begin{tabular}{|c|c|c|}
@@ -277,7 +278,7 @@ The proofs are routine and are omitted.  Historical bounds on $\GAPLARGE$ are re
     J\"{a}rviniemi (2022) \cite{jarviniemi_large_2022} & & $\frac{57}{100} = 0.57$\\
     \hline
     \end{tabular}
-\end{table}\label{gaplarge-table}
+\end{table}
 
 For any $0 < \theta < 1$, let $\PNTEXCEP(\theta)$ denote the least exponent $\mu$ such that for all unbounded $X$, one has $\sum_{x \leq n < x + x^\theta} \Lambda(n) = (1+o(1)) x^\theta$ for all $x \in [X,2X]$ outside of an exceptional set of measure $O(X^{\mu+o(1)})$.  Thus for instance $\PNTEXCEP(\theta)=-\infty$ for $\theta > \PNTALL$ (and $\PNTEXCEP(\theta) \geq 0$ for $\theta < \PNTALL$), and $\PNTEXCEP(\theta) < 1$ implies $\theta \geq \PNTAA$. The quantity $\PNTEXCEP(\theta)$ is clearly non-decreasing in $\theta$.
 


### PR DESCRIPTION
## Summary
- `\label{gaplarge-table}` was placed after `\end{table}` instead of inside the environment.

## Root cause
Same hyperref/counter mismatch as #146: `\ref{gaplarge-table}` on line 245 of `primes.tex` does not resolve to the GAPLARGE bounds table when the label sits after `\end{table}`.

## Fix
Move the label to immediately after `\caption{...}`.

## Test plan
- [ ] `\ref{gaplarge-table}` resolves on the web blueprint


Made with [Cursor](https://cursor.com)