### PR TITLE
fix: move small-primegap-table labels inside table environments

### DIFF
--- a/blueprint/src/chapter/primes.tex
+++ b/blueprint/src/chapter/primes.tex
@@ -386,6 +386,7 @@ Historical progress towards this problem is recorded in \Cref{small-primegap-tab
 
 \begin{table}[ht]
     \caption{Historical progression of bounds related to \eqref{eqn:small-prime-gaps}.}
+    \label{small-primegap-table}
     \centering
     \renewcommand{\arraystretch}{2.2}
     \begin{tabular}{|c|c|c|}
@@ -407,7 +408,7 @@ Historical progress towards this problem is recorded in \Cref{small-primegap-tab
     Polymath 8b (2015) \cite{polymath_variants_2014} & $H_1 \le 246$ & \\
     \hline
     \end{tabular}
-\end{table}\label{small-primegap-table}
+    \end{table}
 
 The current best known lower bound on $G(X)$ is
 \begin{theorem}[Ford--Green--Konyagin--Maynard--Tao (2017) \cite{ford_long_2017}]
@@ -418,6 +419,7 @@ G(X) \gg \frac{\log X \log \log X \log\log\log \log X}{\log \log \log X}
 \end{theorem}
 \begin{table}[ht]
     \caption{Historical progression of bounds related to \eqref{eqn:large-prime-gaps}.}
+    \label{small-primegap-table2}
     \centering
     \renewcommand{\arraystretch}{2.2}
     \begin{tabular}{|c|c|c|}
@@ -442,5 +444,5 @@ G(X) \gg \frac{\log X \log \log X \log\log\log \log X}{\log \log \log X}
     \hline
     Ford--Green--Konyagin--Maynard--Tao (2017) \cite{ford_long_2017} & $\displaystyle G(X) \gg \frac{\log X \log \log X \log\log\log \log X}{\log \log \log X}$ \\
     \hline
-\end{tabular}
-\end{table}\label{small-primegap-table2}
+    \end{tabular}
+    \end{table}


### PR DESCRIPTION
## Summary
- `\Cref{small-primegap-table}` and `\Cref{small-primegap-table2}` pointed at labels placed after `\end{table}`.

## Root cause
In this blueprint, table labels need to live inside the `table` float (after `\caption`) so `\ref`/`\Cref` resolve correctly.

## Fix
Move each label next to its caption, matching the earlier gap-table fixes.

## Test plan
- [ ] `xelatex print.tex` builds and the prime-gap table refs resolve


Made with [Cursor](https://cursor.com)