### PR TITLE
fix: move prime counting table labels inside table environments

### DIFF
--- a/blueprint/src/chapter/prime_counting_function.tex
+++ b/blueprint/src/chapter/prime_counting_function.tex
@@ -44,6 +44,7 @@ There exists a positive constant $A$, such that
 
 \begin{table}[ht]
     \caption{Historical estimates of $\pi(x)$, for $x$ sufficiently large.}
+    \label{prime-error-table}
     \centering
     \renewcommand{\arraystretch}{2.2}
     \begin{tabular}{|c|c|}
@@ -60,7 +61,7 @@ There exists a positive constant $A$, such that
     \hline 
     Korobov, Vinogradov \cite{vinogradov_eine_1958} & $\pi(x) = \operatorname{li}(x) + O\left(x\exp\left(-\dfrac{A(\log x)^{3/5}}{(\log\log x)^{1/5}}\right)\right)$ for some $A > 0$\\
     \hline
-    \end{tabular}\label{prime-error-table}
+    \end{tabular}
 \end{table}
 
 Under the Riemann hypothesis, stronger error bounds are known. 
@@ -103,6 +104,7 @@ Applying \Cref{zero_free_to_pnt}, one obtains the error term estimates in the pr
     \def\arraystretch{2.5}
     \centering
     \caption{Zero free regions for $\zeta(s)$, along with the bound on $\psi(x) - x$ that they imply. Here $A$ represents an absolute, positive constant, which may be different at each occurrence.}
+    \label{zero-free-pnt-table}
     \begin{tabular}{|c|c|c|}
     \hline
     Reference & Zero free region & Bound on $(\psi(x) - x)/x$ \\
@@ -116,7 +118,6 @@ Applying \Cref{zero_free_to_pnt}, one obtains the error term estimates in the pr
     \Cref{zfr-vk} & $\sigma \ge 1 - \dfrac{A}{(\log t)^{2/3}(\log\log t)^{1/3}}$ & $\exp\left(-A\dfrac{(\log x)^{3/5}}{(\log\log x)^{1/5}}\right)$\\
     \hline 
     \end{tabular}
-\label{zero-free-pnt-table}
 \end{table}
 
 The following type of converse statement is also known.


### PR DESCRIPTION
## Summary
`\Cref{prime-error-table}` and `\ref{zero-free-pnt-table}` pointed at labels placed after `\end{tabular}` instead of inside the table float.

## Root cause
Same hyperref counter mismatch fixed in #146 and the recent gap-table label PRs: table labels need to sit after `\caption` inside `\begin{table}`.

## Fix
Move each label next to its caption in `prime_counting_function.tex`.


Made with [Cursor](https://cursor.com)