### PR TITLE
fix: move bt-ctheta-table label inside table environment

### DIFF
--- a/blueprint/src/chapter/brun_titchmarsh.tex
+++ b/blueprint/src/chapter/brun_titchmarsh.tex
@@ -69,6 +69,7 @@ and
     \def\arraystretch{1.2}
     \centering
     \caption{Historical bounds on $C_\theta$}
+    \label{bt-ctheta-table}
     \begin{tabular}{|c|c|c|}
     \hline
     Reference & Range of $\theta$ & Upper bound on $C_\theta$\\
@@ -139,7 +140,6 @@ and
     Xi \& Zheng (2025) \cite{xi-zheng-2} & $[1/2,(\nu (2 \nu +1))/(4 \nu^2 + \nu + 4)]$ & $\frac{8}{6 - 7 \theta + \frac{2 \nu - (3 \nu + 4) \theta}{\nu (2 \nu - 1)}}$ for every integer $\nu \geq 5$ (if $q$ prime)\\
     \hline
     \end{tabular}
-\label{bt-ctheta-table}
 \end{table}
 
 Let $\theta_{\mathrm{char}}$ be the least constant such that for every $\eps>0$ there exists $\delta>0$ such that one has a character sum bound of the form


### PR DESCRIPTION
## Summary
Fixes misplaced `\label{bt-ctheta-table}` in `brun_titchmarsh.tex` (follow-up to #145 / #146).

## Root cause
`\label{bt-ctheta-table}` was placed after `\end{tabular}` instead of inside the `table` environment. LaTeX then fails to attach the label to the table, breaking `\ref{bt-ctheta-table}`.

## Fix
Move the label to immediately after `\caption`, consistent with #146, #156, #157, #165, and #166.

Made with [Cursor](https://cursor.com)