### PR TITLE
fix: correct Baker-Harman-Pintz GAPAA decimal (1/16 ≠ 0.625)

### DIFF
--- a/blueprint/src/chapter/primes.tex
+++ b/blueprint/src/chapter/primes.tex
@@ -154,7 +154,7 @@ Bounds on $\GAPAA$ are recorded in Table \ref{gapaa-table}.
     \hline
     H. Li (1997) \cite{li_short_1997} & $\frac{1}{15}=0.0666\dots$ \\
     \hline
-    Baker--Harman--Pintz (1997) \cite{baker-harman-pintz_goldbach_1997} & $\frac{1}{16} = 0.625$ \\
+    Baker--Harman--Pintz (1997) \cite{baker-harman-pintz_goldbach_1997} & $\frac{1}{16} = 0.0625$ \\
     \hline
     Wong (1996) \cite{wong_thesis_1996}, Jia (1996) \cite{jia_exceptional_1996}, Harman (2007) \cite{harman-book} & $\frac{1}{18} = 0.0555\dots$ \\
     \hline


### PR DESCRIPTION
## Summary
- `primes.tex`: Baker–Harman–Pintz (1997) row had `\frac{1}{16} = 0.625`; should be `0.0625` (`0.625` is `\frac{5}{8}`).

## Test plan
- [ ] Visual check of primes chapter table

Made with [Cursor](https://cursor.com)