### PR TITLE
Fix decimal for 356/873 in Huxley table 17.1

### DIFF
--- a/blueprint/src/chapter/beta.tex
+++ b/blueprint/src/chapter/beta.tex
@@ -317,7 +317,7 @@ $$ \beta(\alpha) \leq \max\left(\alpha + \frac{1-4\alpha}{14}, \frac{5}{6} \alph
     \hline
     $\frac{13+21\alpha}{60}$ & $\frac{356}{873}$ & $\frac{5}{12} = 0.4166\dots$ \\
     \hline
-    $\frac{4+103\alpha}{128}$ & $\frac{12}{31}$ & $\frac{356}{873} = 0.4546\dots$ \\
+    $\frac{4+103\alpha}{128}$ & $\frac{12}{31}$ & $\frac{356}{873} = 0.4077\dots$ \\
     \hline
     $\frac{29+173\alpha}{280}$ & $\frac{227}{601}$ & $\frac{12}{31} = 0.3870\dots$ \\
     \hline


### PR DESCRIPTION
In `blueprint/src/chapter/beta.tex` (Huxley table 17.1), the entry `\frac{356}{873}` is annotated `= 0.4546\dots`, but `356/873 = 0.4077\dots`.

The fraction itself is correct: it matches the `X` entry of the preceding row and fits the strictly decreasing column (0.4166 -> 0.4077 -> 0.3870). Only the decimal expansion was wrong.

Made with [Cursor](https://cursor.com)