### PR TITLE
fix: escape backslash in \leq (invalid escape sequence)

### DIFF
--- a/blueprint/src/python/zero_density_energy_estimate.py
+++ b/blueprint/src/python/zero_density_energy_estimate.py
@@ -49,7 +49,7 @@ class Zero_Density_Energy_Estimate:
         """
         Returns a string representation of the zero density energy estimate.
         """
-        return f"A*(x) \leq {self.expr} on {self.interval}"
+        return f"A*(x) \\leq {self.expr} on {self.interval}"
 
     def _ensure_bound_is_computed(self):
         """
@@ -220,7 +220,7 @@ def add_trivial_zero_density_energy_estimates(hypotheses: Hypothesis_Set):
     estimates from a set of hypothesis, and add them to the hypothesis set.
 
     For example, one has the trivial zero density energy estimate 
-    A^*(\\sigma) \leq 3A(\\sigma)
+    A^*(\\sigma) \\leq 3A(\\sigma)
     where A(\\sigma) is a zero density estimate. 
 
     Parameters


### PR DESCRIPTION
### Problem

`blueprint/src/python/zero_density_energy_estimate.py` uses `\leq` inside two normal (non-raw) Python strings:

- the `__repr__` of `Zero_Density_Energy_Estimate` (`f"A*(x) \leq ..."`)
- the docstring of `add_trivial_zero_density_energy_estimates` (`A^*(\\sigma) \leq 3A(\\sigma)`)

`\l` is not a recognized escape, so Python emits `SyntaxWarning: invalid escape sequence '\l'` (scheduled to become a `SyntaxError`).

### Fix

Write `\\leq`, matching the parallel class `Zero_Density_Estimate.__repr__` in `zero_density_estimate.py`, which already uses `f"A(x) \\leq ..."`. The rendered text is unchanged.

Verified the module compiles with `-W error::SyntaxWarning`.

Made with [Cursor](https://cursor.com)