### PR TITLE
fix: correct typos in Python docstrings and comments

### DIFF
--- a/blueprint/src/python/derived.py
+++ b/blueprint/src/python/derived.py
@@ -574,7 +574,7 @@ def prove_zero_density(
     Prove a zero density estimate for zeta given a set of hypotheses, a range of
     values of sigma, and a choice of tau0.
 
-    Paramters
+    Parameters
     ---------
     additional_hypotheses : list of Hypothesis
         The list of hypothesis from the literature to assume (other than classical

--- a/blueprint/src/python/large_values.py
+++ b/blueprint/src/python/large_values.py
@@ -83,7 +83,7 @@ def convert_bounds(bounds: list) -> Large_Value_Estimate:
     Returns
     -------
     Large_Value_Estimate
-        The correponding Large_Value_Estimate object
+        The corresponding Large_Value_Estimate object
     """
 
     # The default domain of definition in (sigma, tau, rho) space

--- a/blueprint/src/python/literature.py
+++ b/blueprint/src/python/literature.py
@@ -766,7 +766,7 @@ def add_jutila_large_values_estimate(K):
 # Given in Table 7.1 of the LaTeX blueprint
 def add_bourgain_large_values_estimate():
     polys = [
-        # For now - assume that we can't say anthing about LV estimates
+        # For now - assume that we can't say anything about LV estimates
         # for tau <= 1
         Polytope.rect(
             (frac(1,2), frac(1)),                       # 1/2 <= σ <= 1

--- a/blueprint/src/python/tests/test_polytope.py
+++ b/blueprint/src/python/tests/test_polytope.py
@@ -155,7 +155,7 @@ def run_emptiness_tests():
     assert not p8.is_empty(include_boundary=True)
     assert p8.is_empty(include_boundary=False)
 
-    # Region reprsenting a 2-d line
+    # Region representing a 2-d line
     p9 = Polytope([
         [12, -12, -1],
         [frac(15,2), -frac(21,2), frac(1,2)],

--- a/blueprint/src/python/zero_density_estimate.py
+++ b/blueprint/src/python/zero_density_estimate.py
@@ -476,7 +476,7 @@ def lver_to_zd(LVER, LVER_zeta, sigma_interval):
     Parameters
     ----------
     LVER : Hypothesis
-        A regoin that contains the large value energy region, i.e. a region that
+        A region that contains the large value energy region, i.e. a region that
         contains the set of feasible tuples (sigma, tau, rho, rho*, s).
     LVER_zeta : Hypothesis
         A region that contains the zeta large value energy region.


### PR DESCRIPTION
Small typo fixes in `blueprint/src/python` docstrings and comments (no behavioural change):

- `derived.py`: `Paramters` -> `Parameters` (numpydoc section header, so the section now renders correctly)
- `large_values.py`: `correponding` -> `corresponding`
- `literature.py`: `anthing` -> `anything`
- `zero_density_estimate.py`: `regoin` -> `region`
- `tests/test_polytope.py`: `reprsenting` -> `representing`

Made with [Cursor](https://cursor.com)