### PR TITLE
fix: remove duplicated words in blueprint chapters

### DIFF
--- a/blueprint/src/chapter/pythagorean_triples.tex
+++ b/blueprint/src/chapter/pythagorean_triples.tex
@@ -15,7 +15,7 @@ for unbounded $N$ and some fixed $c,c'$, where $P(N)$ is the number of primitive
 $$ \Pythag \leq \max( \frac{1}{3} - \frac{5}{6} \frac{k+\ell-3/2}{4(k+\ell)-7}, \frac{1}{2} - \frac{3}{2}\frac{k+\ell-3/2}{4(k+\ell)-7} )$$
 \end{lemma}
 
-\begin{proof} See \cite{menzer} and and \cite[Section 5.10]{trudgian-yang}.
+\begin{proof} See \cite{menzer} and \cite[Section 5.10]{trudgian-yang}.
 \end{proof}
 
 \begin{lemma}\label{pythag-71-316}\uses{pythag-def} Assuming RH, one has $\Pythag \leq 71/316$.

--- a/blueprint/src/chapter/zero_density.tex
+++ b/blueprint/src/chapter/zero_density.tex
@@ -631,7 +631,7 @@ whenever
 
 \begin{proof}\uses{hb-12, a-ivt-1, zero-large-cor2} With the hypothesis on $\sigma$, one sees from Lemma \ref{a-ivt-1} that
 $$ \LV(\sigma,\tau) \leq \max( 2 - 2 \sigma, \tau - \frac{(4m-2)\sigma + 2-2m}{m} + 2-2\sigma)$$
-for $0 \leq \tau < \frac{(4m-2)\sigma + 2-2m}{m}$, and hence for all $\tau \geq 0$ by by Lemma \ref{lv-basic}(ii).  Meanwhile, from Theorem \ref{hb-12} one has
+for $0 \leq \tau < \frac{(4m-2)\sigma + 2-2m}{m}$, and hence for all $\tau \geq 0$ by Lemma \ref{lv-basic}(ii).  Meanwhile, from Theorem \ref{hb-12} one has
 $$\LV_\zeta(\sigma,\tau) \leq 2\tau - 12 (\sigma-1/2)$$
 for all $\tau \geq 2$.  The claim then follows from Corollary
 \ref{zero-large-cor2} with $\tau_0 := \frac{(3m-2)\sigma+2-m}{m}$ after a routine calculation.


### PR DESCRIPTION
Two duplicated-word typos in blueprint prose:

- `chapter/zero_density.tex`: `... for all $\tau \geq 0$ by by Lemma \ref{lv-basic}(ii)` -> `by Lemma`
- `chapter/pythagorean_triples.tex`: `See \cite{menzer} and and \cite[Section 5.10]{trudgian-yang}` -> `and \cite`

Made with [Cursor](https://cursor.com)