### PR TITLE
Fix upper limit in the li(x) definition (should be x, not infinity)

### DIFF
--- a/blueprint/src/chapter/prime_counting_function.tex
+++ b/blueprint/src/chapter/prime_counting_function.tex
@@ -16,7 +16,7 @@ These functions, particularly $\pi(x)$, are central to number theory because the
 \begin{theorem}[Prime number theorem]
 As $x \to \infty$, 
 \[
-\pi(x) \sim \frac{x}{\log x} \sim \operatorname{li}(x) := \int_2^{\infty}\frac{dt}{\log t}.
+\pi(x) \sim \frac{x}{\log x} \sim \operatorname{li}(x) := \int_2^{x}\frac{dt}{\log t}.
 \]
 \end{theorem}
 


### PR DESCRIPTION
In the prime number theorem statement, the logarithmic integral is defined as
$$\operatorname{li}(x) := \int_2^{\infty}\frac{dt}{\log t},$$
but that integral diverges (the integrand $1/\log t$ does not decay). The upper limit should be $x$:
$$\operatorname{li}(x) := \int_2^{x}\frac{dt}{\log t}.$$

This matches the $\operatorname{li}(x)$ used everywhere else in the chapter (e.g. $\pi(x) = \operatorname{li}(x) + O(\dots)$).

Made with [Cursor](https://cursor.com)