### PR TITLE
prime_gap: print beta in the beta debug block (was printing alpha)

### DIFF
--- a/blueprint/src/python/prime_gap.py
+++ b/blueprint/src/python/prime_gap.py
@@ -64,7 +64,7 @@ def compute_gap2(hypotheses, debug=False):
         if debug:
             print("beta --------------------------------------------------")
             for p in statpts:
-                print(p, float(p), alpha.subs(x, p), float(alpha.subs(x, p)))
+                print(p, float(p), beta.subs(x, p), float(beta.subs(x, p)))
 
         print(interval, max(sup_alpha, sup_beta), alpha.simplify(), beta.simplify())
 


### PR DESCRIPTION
In `compute_gap2`, the `debug` block for `beta` prints `alpha` instead of `beta`:

```python
# Do the same for beta
...
if debug:
    print("beta ...")
    for p in statpts:
        print(p, float(p), alpha.subs(x, p), float(alpha.subs(x, p)))
```

The `beta` statpts are computed just above, so the debug output should evaluate `beta` at those points. Debug-only; no effect on returned values.

Made with [Cursor](https://cursor.com)