### PR TITLE
fix: duplicated "and" in pythagorean_triples citation

### DIFF
--- a/blueprint/src/chapter/pythagorean_triples.tex
+++ b/blueprint/src/chapter/pythagorean_triples.tex
@@ -15,7 +15,7 @@ for unbounded $N$ and some fixed $c,c'$, where $P(N)$ is the number of primitive
 $$ \Pythag \leq \max( \frac{1}{3} - \frac{5}{6} \frac{k+\ell-3/2}{4(k+\ell)-7}, \frac{1}{2} - \frac{3}{2}\frac{k+\ell-3/2}{4(k+\ell)-7} )$$
 \end{lemma}
 
-\begin{proof} See \cite{menzer} and and \cite[Section 5.10]{trudgian-yang}.
+\begin{proof} See \cite{menzer} and \cite[Section 5.10]{trudgian-yang}.
 \end{proof}
 
 \begin{lemma}\label{pythag-71-316}\uses{pythag-def} Assuming RH, one has $\Pythag \leq 71/316$.


### PR DESCRIPTION
## Summary
Proof citation had `and and` instead of `and`.

## Test plan
- [ ] Blueprint compiles

Made with [Cursor](https://cursor.com)