### PR TITLE
Fixed the proof of Lemma 3.1 of Chapter 3 Basic Fourier Estimates

### DIFF
--- a/expdb.lean
+++ b/expdb.lean
@@ -1,1 +1,2 @@
-import expdb.Example
+import expdb.basic
+import expdb.basic_fourier_estimates

--- a/expdb/basic.lean
+++ b/expdb/basic.lean
@@ -117,29 +117,38 @@ lemma indicatorFunction_values {α : Type*} [DecidableEq α]
 example (W : Finset ℝ) : W.card = Finset.card W := rfl
 
 -- ===========================================================
---  Separated Sequences
+--  Separated families and sets
 -- ===========================================================
 
-/-- 1-Separated Sets: distance between distinct elements is at least 1 -/
-def IsSeparated (W : Finset ℝ) : Prop :=
-  ∀ t ∈ W, ∀ t' ∈ W, t ≠ t' → 1 ≤ |t - t'|
+/-- A family of real numbers is `δ`-separated when distinct indices have values at least
+`δ` apart. -/
+def IsSeparatedFamily {ι : Type*} (δ : ℝ) (x : ι → ℝ) : Prop :=
+  ∀ i j, i ≠ j → δ ≤ |x i - x j|
 
 /-- λ-Separated Sets: distance between distinct elements is at least λ -/
 def IsLambdaSeparated (lam : ℝ) (W : Finset ℝ) : Prop :=
-  ∀ t ∈ W, ∀ t' ∈ W, t ≠ t' → lam ≤ |t - t'|
+  IsSeparatedFamily lam fun t : W.attach => (t : ℝ)
+
+/-- 1-Separated Sets: distance between distinct elements is at least 1. -/
+abbrev IsOneSeparated (W : Finset ℝ) : Prop :=
+  IsLambdaSeparated 1 W
 
 /-- 1-separated is structurally identical to λ-separated with λ = 1 -/
-lemma isSeparated_iff_isLambdaSeparated_one (W : Finset ℝ) :
-    IsSeparated W ↔ IsLambdaSeparated 1 W := by
+lemma isOneSeparated_iff_isLambdaSeparated_one (W : Finset ℝ) :
+    IsOneSeparated W ↔ IsLambdaSeparated 1 W := by
   rfl
 
 -- ===========================================================
--- 1-Bounded Sequences
+-- Bounded families
 -- ===========================================================
 
-/-- 1-Bounded complex sequence: |aₙ| ≤ 1 for all n -/
-def IsOneBounded (a : ℕ → ℂ) : Prop :=
-  ∀ n, ‖a n‖ ≤ 1
+/-- A complex family is `C`-bounded when every value has norm at most `C`. -/
+def IsBoundedFamily {ι : Type*} (C : ℝ) (a : ι → ℂ) : Prop :=
+  ∀ i, ‖a i‖ ≤ C
+
+/-- A complex family is 1-bounded. -/
+abbrev IsOneBounded {ι : Type*} (a : ι → ℂ) : Prop :=
+  IsBoundedFamily 1 a
 
 /-- The phase sequence e(θₙ) is always 1-bounded -/
 lemma e_is_one_bounded (θ : ℕ → ℝ) : IsOneBounded (fun n => e (θ n)) := by

--- a/expdb/basic.lean
+++ b/expdb/basic.lean
@@ -3,118 +3,13 @@
   ===============================================
 -/
 
-import Mathlib.Analysis.SpecialFunctions.Complex.Circle
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
-import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Analysis.Normed.Field.Basic
-import Mathlib.Analysis.Asymptotics.Defs
-import Mathlib.Data.EReal.Basic
+import Mathlib.Analysis.Complex.Norm
+import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Topology.MetricSpace.Sequences
 
-open Filter Topology Asymptotics Real
-
--- ===========================================================
---  Function e(θ) = exp(2πiθ)
--- ===========================================================
-
-/-- Definition: e(θ) := e^(2πiθ) as defined in Blueprint p. 4 -/
-noncomputable def e (θ : ℝ) : ℂ :=
-  Complex.exp (2 * Real.pi * θ * Complex.I)
-
-/-- Base case: e(0) = 1 -/
-lemma e_zero : e 0 = 1 := by
-  simp [e]
-
-/-- Absolute value / Norm: |e(θ)| = 1 for all θ -/
-lemma norm_e (θ : ℝ) : ‖e θ‖ = 1 := by
-  rw [e, Complex.norm_exp]
-  simp
-
-/-- Homomorphism property: e(θ₁ + θ₂) = e(θ₁) * e(θ₂) -/
-lemma e_add (θ₁ θ₂ : ℝ) : e (θ₁ + θ₂) = e θ₁ * e θ₂ := by
-  simp [e, ← Complex.exp_add]
-  congr 1
-  ring
-
-/-- Periodicity over integers: e(n) = 1 for any n : ℤ -/
-lemma e_int (n : ℤ) : e n = 1 := by
-  have h : (2 * Real.pi * (n : ℝ) * Complex.I) = (n : ℂ) * (2 * Real.pi * Complex.I) := by
-    push_cast; ring
-  rw [e, h]
-  exact Complex.exp_int_mul_two_pi_mul_I n
-
--- ===========================================================
--- Empty Supremum / Infimum Conventions
--- ===========================================================
-
-/-- Convention: empty supremum = -∞ (⊥ in EReal) -/
-lemma blueprintSup_empty_convention :
-    sSup (∅ : Set EReal) = ⊥ :=
-  sSup_empty
-
-/-- Convention: empty infimum = +∞ (⊤ in EReal) -/
-lemma blueprintInf_empty_convention :
-    sInf (∅ : Set EReal) = ⊤ :=
-  sInf_empty
-
-/-- sup_{σ₀ ≤ σ < σ₁} f(σ) = -∞ when σ₁ < σ₀ -/
-noncomputable def blueprintSup (σ₀ σ₁ : ℝ) (f : ℝ → EReal) : EReal :=
-  sSup (f '' {σ : ℝ | σ₀ ≤ σ ∧ σ < σ₁})
-
-lemma blueprintSup_empty {σ₀ σ₁ : ℝ} (f : ℝ → EReal) (h : σ₁ < σ₀) :
-    blueprintSup σ₀ σ₁ f = ⊥ := by
-  have h_empty : {σ : ℝ | σ₀ ≤ σ ∧ σ < σ₁} = ∅ := by
-    ext σ
-    simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
-    intro ⟨h1, h2⟩
-    linarith
-  simp [blueprintSup, h_empty]
-
--- ===========================================================
--- N^(-∞) = 0 Convention
--- ===========================================================
-
-/-- Extended real power: handles N^r for r : EReal.
-    The only special case stated in the blueprint is N^(-∞) = 0 when N > 1.
-    For r = +∞ we leave it as the natural limit (not specified by blueprint). -/
-noncomputable def blueprintPower (N : ℝ) (r : EReal) : ℝ :=
-  if r = ⊥ then 0
-  else N ^ r.toReal
-
-/-- Blueprint convention: N^(-∞) = 0 for N > 1 -/
-lemma blueprintPower_bot {N : ℝ} (hN : N > 1) :
-    blueprintPower N ⊥ = 0 := by
-  simp [blueprintPower]
-
-/-- For finite exponents, blueprintPower agrees with real power -/
-lemma blueprintPower_coe {N : ℝ} (r : ℝ) :
-    blueprintPower N (r : EReal) = N ^ r := by
-  simp [blueprintPower, EReal.coe_ne_bot, EReal.toReal_coe]
-
--- ===========================================================
--- Indicator Function
--- ===========================================================
-
-/-- 1_I(n) = 1 if n ∈ I, else 0 -/
-def indicatorFunction {α : Type*} [DecidableEq α] (I : Set α)
-    [DecidablePred (· ∈ I)] (n : α) : ℝ :=
-  if n ∈ I then 1 else 0
-
-/-- Indicator is 0 or 1 -/
-lemma indicatorFunction_values {α : Type*} [DecidableEq α]
-    (I : Set α) [DecidablePred (· ∈ I)] (n : α) :
-    indicatorFunction I n = 0 ∨ indicatorFunction I n = 1 := by
-  unfold indicatorFunction
-  split_ifs <;> simp
-
--- ===========================================================
--- Cardinality |W| for Finsets
--- ===========================================================
-
-/-- We use Finset.card for cardinality, written |W| in the blueprint.
-    In Lean we use W.card or Finset.card W to avoid notation conflicts. -/
-example (W : Finset ℝ) : W.card = Finset.card W := rfl
+open Filter Topology Real
 
 -- ===========================================================
 --  Separated families and sets
@@ -133,40 +28,26 @@ def IsLambdaSeparated (lam : ℝ) (W : Finset ℝ) : Prop :=
 abbrev IsOneSeparated (W : Finset ℝ) : Prop :=
   IsLambdaSeparated 1 W
 
-/-- 1-separated is structurally identical to λ-separated with λ = 1 -/
-lemma isOneSeparated_iff_isLambdaSeparated_one (W : Finset ℝ) :
-    IsOneSeparated W ↔ IsLambdaSeparated 1 W := by
-  rfl
-
 -- ===========================================================
 -- Bounded families
 -- ===========================================================
 
-/-- A complex family is `C`-bounded when every value has norm at most `C`. -/
-def IsBoundedFamily {ι : Type*} (C : ℝ) (a : ι → ℂ) : Prop :=
+/-- A family in a normed type is `C`-bounded when every value has norm at most `C`. -/
+def IsBoundedFamily {ι β : Type*} [Norm β] (C : ℝ) (a : ι → β) : Prop :=
   ∀ i, ‖a i‖ ≤ C
 
-/-- A complex family is 1-bounded. -/
-abbrev IsOneBounded {ι : Type*} (a : ι → ℂ) : Prop :=
+/-- A family in a normed type is 1-bounded. -/
+abbrev IsOneBounded {ι β : Type*} [Norm β] (a : ι → β) : Prop :=
   IsBoundedFamily 1 a
-
-/-- The phase sequence e(θₙ) is always 1-bounded -/
-lemma e_is_one_bounded (θ : ℕ → ℝ) : IsOneBounded (fun n => e (θ n)) := by
-  intro n
-  rw [norm_e]
 
 -- ===========================================================
 -- Asymptotic Notation
 -- ===========================================================
 
-/-- An infinitesimal sequence: a sequence that converges to 0 -/
-def IsInfinitesimal (X : ℕ → ℝ) : Prop :=
-  Tendsto X atTop (nhds 0)
-
 /-- X ≤ Y + o(1) in a strict sense:
     There exists an infinitesimal sequence ε_i such that x_i ≤ y_i + ε_i eventually. -/
 def EventuallyLeUpToInfinitesimal (X Y : ℕ → ℝ) : Prop :=
-  ∃ ε : ℕ → ℝ, IsInfinitesimal ε ∧
+  ∃ ε : ℕ → ℝ, Tendsto ε atTop (nhds 0) ∧
                (∀ᶠ i in atTop, X i ≤ Y i + ε i)
 
 -- Notation shorthand
@@ -296,7 +177,7 @@ theorem underspill (X Y : ℕ → ℝ) :
       have hc2 : c / 2 > 0 := by linarith
       obtain ⟨dseq, hdseq_inf, hdseq_bound⟩ := h (c / 2) hc2
       -- dseq → 0, so ∀ᶠ i, |dseq i| < c/2
-      rw [IsInfinitesimal, Metric.tendsto_nhds] at hdseq_inf
+      rw [Metric.tendsto_nhds] at hdseq_inf
       have hdseq_small := hdseq_inf (c / 2) hc2
       -- For sufficiently large i: x_i ≤ y_i + c/2 + dseq_i and |dseq_i| < c/2
       filter_upwards [hdseq_bound, hdseq_small] with i hi_bound hi_small
@@ -326,7 +207,7 @@ theorem underspill (X Y : ℕ → ℝ) :
     use fun i => max (X i - Y i) 0
     constructor
     · -- We prove that max(x_i - y_i, 0) → 0
-      rw [IsInfinitesimal, Metric.tendsto_nhds]
+      rw [Metric.tendsto_nhds]
       intro δ hδ
       -- From key with c = δ
       have h_ev := key δ hδ
@@ -345,32 +226,6 @@ theorem underspill (X Y : ℕ → ℝ) :
       linarith
 
 -- ============================================================
--- Asymptotic relations  X = O(Y),  X ≪ Y,  X ≍ Y
--- ============================================================
-
-/-- X = O(Y): there exists a fixed C with |X| ≤ C·Y eventually. -/
-def IsBigOSeq (X Y : ℕ → ℝ) : Prop :=
-  ∃ C : ℝ, 0 < C ∧ ∀ᶠ i in atTop, |X i| ≤ C * Y i
-
-/-- X ≪ Y  (X is much less than Y):
-    same as X = O(Y) in the blueprint's variable-quantity sense. -/
-def IsVeryLT (X Y : ℕ → ℝ) : Prop := IsBigOSeq X Y
-
-notation X " ≪ " Y => IsVeryLT X Y
-notation Y " ≫ " X => IsVeryLT X Y
-
-/-- X = o(Y): there exists an infinitesimal c with |X| ≤ c·Y eventually. -/
-def IsLittleOSeq (X Y : ℕ → ℝ) : Prop :=
-  ∃ c : ℕ → ℝ, IsInfinitesimal c ∧ ∀ᶠ i in atTop, |X i| ≤ c i * Y i
-
-/-- X ≍ Y  (X and Y are comparable):
-    X ≪ Y and Y ≪ X,  i.e. X = O(Y) and Y = O(X). -/
-def IsAsymptoticallyEquiv (X Y : ℕ → ℝ) : Prop :=
-  (X ≪ Y) ∧ (Y ≪ X)
-
-notation X " ≍ " Y => IsAsymptoticallyEquiv X Y
-
--- ============================================================
 -- Pointwise-bounded and pointwise-infinitesimal functions
 -- ============================================================
 
@@ -382,7 +237,7 @@ def IsPointwiseBounded (E : ℕ → Set ℝ) (f : ∀ i, E i → ℂ) : Prop :=
 /-- f is pointwise o(1): for every variable sequence (x_i) ∈ E_i,
     the values (f_i(x_i)) tend to 0. -/
 def IsPointwiseInfinitesimal (E : ℕ → Set ℝ) (f : ∀ i, E i → ℂ) : Prop :=
-  ∀ x : ∀ i, E i, IsInfinitesimal (fun i => ‖f i (x i)‖)
+  ∀ x : ∀ i, E i, Tendsto (fun i => ‖f i (x i)‖) atTop (nhds 0)
 
 -- ============================================================
 -- Proposition 2.1 — Automatic uniformity
@@ -474,7 +329,7 @@ theorem automatic_uniformity_ii
     (f : ∀ i, E i → ℂ)
     (hf : IsPointwiseInfinitesimal E f) :
     ∃ φ : ℕ → ℕ, StrictMono φ ∧
-    ∃ c : ℕ → ℝ, IsInfinitesimal c ∧
+    ∃ c : ℕ → ℝ, Tendsto c atTop (nhds 0) ∧
     ∀ i, ∀ x : E (φ i),
     ‖f (φ i) x‖ ≤ c i := by
   -- Step 1: for each n ≥ 1, the bound 1/n eventually holds uniformly
@@ -494,7 +349,7 @@ theorem automatic_uniformity_ii
         (show E (φ h.choose) = E j by rw [h.choose_spec]) ▸ x_bad h.choose
       else default_elem j
     have hfy := hf y
-    rw [IsInfinitesimal, Metric.tendsto_atTop] at hfy
+    rw [Metric.tendsto_atTop] at hfy
     obtain ⟨N₀, hN₀⟩ := hfy (1/(2*n)) (by positivity)
     obtain ⟨m, hm⟩ := (hφ.tendsto_atTop).eventually (eventually_ge_atTop N₀) |>.exists
     have heq :=
@@ -510,5 +365,4 @@ theorem automatic_uniformity_ii
   -- Step 2: build strictly increasing thresholds and conclude
   obtain ⟨φ, hφ, hφ_bd⟩ := build_increasing_thresholds E f scale
   refine ⟨φ, hφ, fun n => 1/(↑n+1), ?_, hφ_bd⟩
-  rw [IsInfinitesimal]
   exact tendsto_one_div_add_atTop_nhds_zero_nat

--- a/expdb/basic.lean
+++ b/expdb/basic.lean
@@ -28,17 +28,17 @@ open Filter Topology Real
 --  Separated families and sets
 -- ===========================================================
 
-/-- A family of real numbers is `δ`-separated when distinct indices have values at least
-`δ` apart. -/
-def IsSeparatedFamily {ι : Type*} (δ : ℝ) (x : ι → ℝ) : Prop :=
-  ∀ i j, i ≠ j → δ ≤ |x i - x j|
+/-- A family in a pseudo-metric space is `δ`-separated when distinct indices have values at
+least `δ` apart. This uses a non-strict inequality, unlike `Metric.IsSeparated`. -/
+def IsSeparatedFamily {ι α : Type*} [PseudoMetricSpace α] (δ : ℝ) (x : ι → α) : Prop :=
+  Pairwise fun i j => δ ≤ dist (x i) (x j)
 
 /-- λ-Separated Sets: distance between distinct elements is at least λ -/
-def IsLambdaSeparated (lam : ℝ) (W : Finset ℝ) : Prop :=
-  IsSeparatedFamily lam fun t : W.attach => (t : ℝ)
+def IsLambdaSeparated {α : Type*} [PseudoMetricSpace α] (lam : ℝ) (W : Finset α) : Prop :=
+  IsSeparatedFamily lam fun t : W => (t : α)
 
 /-- 1-Separated Sets: distance between distinct elements is at least 1. -/
-abbrev IsOneSeparated (W : Finset ℝ) : Prop :=
+abbrev IsOneSeparated {α : Type*} [PseudoMetricSpace α] (W : Finset α) : Prop :=
   IsLambdaSeparated 1 W
 
 -- ===========================================================
@@ -148,94 +148,30 @@ theorem underspill (X Y : ℕ → ℝ) :
     (X ≤o Y) ↔
     (∀ ε : ℝ, ε > 0 → X ≤o (fun i => Y i + ε)) := by
   constructor
-
-  -- =======================
-  -- Forward Direction (→)
-  -- =======================
   · intro ⟨εseq, hεseq_inf, hεseq_bound⟩ ε hε
-    -- We choose the exact same sequence εseq
-    -- x_i ≤ y_i + εseq_i ≤ y_i + ε + εseq_i
-    use εseq
-    constructor
-    · exact hεseq_inf
+    refine ⟨εseq, hεseq_inf, ?_⟩
     · filter_upwards [hεseq_bound] with i hi
-      -- hi : x_i ≤ y_i + εseq_i
-      -- Goal: x_i ≤ (y_i + ε) + εseq_i
       linarith
-
-  -- =======================
-  -- Backward Direction (←)
-  -- =======================
   · intro h
-    -- We want to construct an infinitesimal sequence d_i such that x_i ≤ y_i + d_i
-    -- Strategy: For each c > 0, by hypothesis with ε = c/2:
-    --   x_i ≤ y_i + c/2 + d_i where d_i → 0
-    --   For sufficiently large i: d_i < c/2
-    --   Therefore: x_i ≤ y_i + c
-    -- This implies: x_i - y_i ≤ c for all c > 0
-    -- We build the sequence explicitly.
-
-    -- For each n : ℕ, use ε = 1/(n+1)
-    -- From the hypothesis, we obtain d^n_i such that x_i ≤ y_i + 1/(n+1) + d^n_i
-    -- We define ε_i = inf_{n} (1/(n+1) + d^n_i)
-    -- However, this is complex, so we use a more direct approach:
-
-    -- We define z_i = max(x_i - y_i, 0)
-    -- and prove that z_i → 0
-
-    -- First, we prove: ∀ c > 0, ∀ᶠ i, x_i - y_i < c
     have key : ∀ c : ℝ, c > 0 → ∀ᶠ i in atTop, X i - Y i < c := by
       intro c hc
-      -- Use the hypothesis with ε = c/2
       have hc2 : c / 2 > 0 := by linarith
       obtain ⟨dseq, hdseq_inf, hdseq_bound⟩ := h (c / 2) hc2
-      -- dseq → 0, so ∀ᶠ i, |dseq i| < c/2
       rw [Metric.tendsto_nhds] at hdseq_inf
       have hdseq_small := hdseq_inf (c / 2) hc2
-      -- For sufficiently large i: x_i ≤ y_i + c/2 + dseq_i and |dseq_i| < c/2
       filter_upwards [hdseq_bound, hdseq_small] with i hi_bound hi_small
-      -- hi_bound : x_i ≤ y_i + c/2 + dseq_i
-      -- hi_small : dist (dseq i) 0 < c/2, i.e., |dseq_i| < c/2
       rw [Real.dist_eq] at hi_small
       simp at hi_small
-      -- dseq_i < c/2 follows from |dseq_i| < c/2
-      have hdseq_lt : dseq i < c / 2 := by
-        exact lt_of_abs_lt hi_small
+      have hdseq_lt : dseq i < c / 2 := lt_of_abs_lt hi_small
       linarith
-
-    -- Now we construct the infinitesimal sequence
-    -- We use the sequence z_i = max(x_i - y_i, 0)
-    -- and prove that it converges to 0
-
-    -- Alternatively, more simply: we use x_i - y_i directly
-    -- and prove that (x_i - y_i)⁺ → 0, then conclude
-
-    -- For simplicity, we show the existence of ε_i = max(x_i - y_i, 1/i) approximately
-    -- But the simplest proof uses the squeeze theorem
-
-    -- We define ε_i explicitly via: for any i, take 1/(i+1) as an approximation
-    -- If x_i ≤ y_i + 1/(i+1) + d_i where d_i → 0
-
-    -- Direct proof: we show x_i - y_i → 0 by definition
-    use fun i => max (X i - Y i) 0
-    constructor
-    · -- We prove that max(x_i - y_i, 0) → 0
+    refine ⟨fun i => max (X i - Y i) 0, ?_, Filter.Eventually.of_forall fun i => ?_⟩
+    ·
       rw [Metric.tendsto_nhds]
       intro δ hδ
-      -- From key with c = δ
-      have h_ev := key δ hδ
-      -- We also need x_i - y_i > -δ, but this is not guaranteed
-      -- In fact, max(z, 0) ≤ |z|, so it suffices that |x_i - y_i| < δ
-      -- But key only provides x_i - y_i < δ
-      -- We use key with c = δ
-      filter_upwards [h_ev] with i hi
-      -- hi : x_i - y_i < δ
+      filter_upwards [key δ hδ] with i hi
       rw [Real.dist_eq, sub_zero, abs_of_nonneg (le_max_right _ _)]
       exact max_lt hi hδ
-    · -- We prove x_i ≤ y_i + max(x_i - y_i, 0)
-      apply Filter.Eventually.of_forall
-      intro i
-      have : max (X i - Y i) 0 ≥ X i - Y i := le_max_left _ _
+    · have : X i - Y i ≤ max (X i - Y i) 0 := le_max_left _ _
       linarith
 
 -- ============================================================
@@ -256,23 +192,25 @@ def IsPointwiseInfinitesimal (E : ℕ → Set ℝ) (f : ∀ i, E i → ℂ) : Pr
 -- Proposition 2.1 — Automatic uniformity
 -- ============================================================
 
--- Helper: rewrite |f(φ m)(y(φ m))| as |f(φ m)(x_bad m)| avoiding cast issues.
+private noncomputable def extend_subsequence
+    (E : ℕ → Set ℝ) (hE : ∀ i, (E i).Nonempty)
+    (φ : ℕ → ℕ) (x : ∀ n, E (φ n)) : ∀ j, E j := by
+  classical
+  exact fun j =>
+    if h : ∃ n, φ n = j then
+      (show E (φ h.choose) = E j by rw [h.choose_spec]) ▸ x h.choose
+    else ⟨(hE j).choose, (hE j).choose_spec⟩
+
 open Classical in
-private lemma abs_y_eq_abs_x_bad
-    {E : ℕ → Set ℝ} {f : ∀ i, E i → ℂ}
-    {φ : ℕ → ℕ} (hφ : StrictMono φ)
-    {x_bad : ∀ n, E (φ n)}
-    {default_elem : ∀ i, E i}
-    (m : ℕ) :
-    let y : ∀ j, E j := fun j =>
-      if h : ∃ n, φ n = j then
-        (show E (φ h.choose) = E j by rw [h.choose_spec]) ▸ x_bad h.choose
-      else default_elem j
-    ‖f (φ m) (y (φ m))‖ = ‖f (φ m) (x_bad m)‖ := by
-  simp only []
+private lemma norm_extend_subsequence_apply
+    {E : ℕ → Set ℝ} (hE : ∀ i, (E i).Nonempty)
+    {f : ∀ i, E i → ℂ} {φ : ℕ → ℕ} (hφ : StrictMono φ)
+    (x : ∀ n, E (φ n)) (m : ℕ) :
+    ‖f (φ m) (extend_subsequence E hE φ x (φ m))‖ = ‖f (φ m) (x m)‖ := by
+  simp only [extend_subsequence]
   split_ifs with h
   · have hm : h.choose = m := hφ.injective h.choose_spec
-    have hx : x_bad h.choose ≍ x_bad m := by rw [hm]
+    have hx : x h.choose ≍ x m := by rw [hm]
     apply congrArg
     apply congrArg
     apply eq_of_heq
@@ -299,14 +237,7 @@ theorem automatic_uniformity_i
       rcases Filter.frequently_atTop.mp (h_fail id strictMono_id j) j with ⟨i, hi, x, hx⟩
       exact ⟨i, hi, x, hx⟩
     obtain ⟨φ, hφ, x_bad, hx_bad⟩ := extract_bad_seq_i E f bad
-    -- Extend x_bad to a full variable sequence y
-    let default_elem : ∀ i, E i :=
-      fun i => ⟨(hE i).choose, (hE i).choose_spec⟩
-    classical
-    let y : ∀ j, E j := fun j =>
-      if h : ∃ n, φ n = j then
-        (show E (φ h.choose) = E j by rw [h.choose_spec]) ▸ x_bad h.choose
-      else default_elem j
+    let y : ∀ j, E j := extend_subsequence E hE φ x_bad
     -- Apply pointwise bound to y
     obtain ⟨C_y, hC_y⟩ := hf y
     rw [Filter.eventually_atTop] at hC_y
@@ -317,9 +248,7 @@ theorem automatic_uniformity_i
       obtain ⟨m, hm⟩ := (hφ.tendsto_atTop).eventually (eventually_ge_atTop j₀) |>.exists
       exact ⟨max m (n₁+1), le_trans hm (hφ.monotone (le_max_left _ _)), by omega⟩
     -- Derive contradiction
-    have heq :=
-      abs_y_eq_abs_x_bad (f := f) (φ := φ) (x_bad := x_bad)
-        (default_elem := default_elem) hφ m
+    have heq := norm_extend_subsequence_apply hE (f := f) hφ x_bad m
     linarith [hj₀ (φ m) hm_ge,
               hx_bad m,
               show C_y < (m:ℝ) from
@@ -354,20 +283,12 @@ theorem automatic_uniformity_ii
       fun j => by obtain ⟨i, hi, x, hx⟩ := h_fail j; exact ⟨i, hi, x, hx⟩
     obtain ⟨φ, hφ, x_bad, hx_bad⟩ :=
       extract_bad_seq_ii E f bad
-    let default_elem : ∀ i, E i :=
-      fun i => ⟨(hE i).choose, (hE i).choose_spec⟩
-    classical
-    let y : ∀ j, E j := fun j =>
-      if h : ∃ m, φ m = j then
-        (show E (φ h.choose) = E j by rw [h.choose_spec]) ▸ x_bad h.choose
-      else default_elem j
+    let y : ∀ j, E j := extend_subsequence E hE φ x_bad
     have hfy := hf y
     rw [Metric.tendsto_atTop] at hfy
     obtain ⟨N₀, hN₀⟩ := hfy (1/(2*n)) (by positivity)
     obtain ⟨m, hm⟩ := (hφ.tendsto_atTop).eventually (eventually_ge_atTop N₀) |>.exists
-    have heq :=
-      abs_y_eq_abs_x_bad (f := f) (φ := φ) (x_bad := x_bad)
-      (default_elem := default_elem) hφ m
+    have heq := norm_extend_subsequence_apply hE (f := f) hφ x_bad m
     have h1 : ‖f (φ m) (y (φ m))‖ < 1/(2*n) := by
       have := hN₀ (φ m) hm
       rwa [Real.dist_eq, sub_zero, abs_of_nonneg (norm_nonneg _)] at this

--- a/expdb/basic.lean
+++ b/expdb/basic.lean
@@ -11,12 +11,12 @@ import Mathlib.Topology.MetricSpace.Sequences
 This file defines the project-specific notions used in Chapter 2. When a blueprint convention
 already has a standard Mathlib representation, later files use that representation directly:
 
-* the notation `e(θ)` is `𝐞 θ` after `open scoped FourierTransform`; it is coerced from
+-the notation `e(θ)` is `𝐞 θ` after `open scoped FourierTransform`; it is coerced from
   `Circle` to `ℂ` when the surrounding expression requires a complex number;
-* indicator functions are written using `Set.indicator`;
-* suprema and infima, including those of empty sets, use Mathlib's `sSup` and `sInf`;
-* finite cardinalities use `Finset.card`;
-* standard asymptotic relations use Mathlib's `Asymptotics` API.
+-indicator functions are written using `Set.indicator`;
+-suprema and infima, including those of empty sets, use Mathlib's `sSup` and `sInf`;
+-finite cardinalities use `Finset.card`;
+-standard asymptotic relations use Mathlib's `Asymptotics` API.
 
 New declarations are introduced here only when the notion used by the blueprint is genuinely
 project-specific or differs from the corresponding Mathlib notion.

--- a/expdb/basic.lean
+++ b/expdb/basic.lean
@@ -9,14 +9,26 @@ import Mathlib.Topology.MetricSpace.Sequences
 # ANTEDB Blueprint — Chapter 2: Basic notation
 
 This file defines the project-specific notions used in Chapter 2. When a blueprint convention
-already has a standard Mathlib representation, later files use that representation directly:
-
+already has a standard Mathlib representation, prefer using that representation directly:
 -the notation `e(θ)` is `𝐞 θ` after `open scoped FourierTransform`; it is coerced from
   `Circle` to `ℂ` when the surrounding expression requires a complex number;
 -indicator functions are written using `Set.indicator`;
 -suprema and infima, including those of empty sets, use Mathlib's `sSup` and `sInf`;
 -finite cardinalities use `Finset.card`;
 -standard asymptotic relations use Mathlib's `Asymptotics` API.
+
+The blueprint also uses non-standard objects indexed by some ambient
+parameter. Their asymptotic properties can be expressed using Mathlib's filter API:
+-a bounded variable `X` satisfies
+ `∃ C : ℝ, ∀ᶠ i in atTop, ‖X i‖ ≤ C`;
+-an unbounded variable `X` satisfies
+ `Tendsto (fun i => ‖X i‖) atTop atTop`;
+-an infinitesimal variable `X` satisfies
+ `Tendsto X atTop (nhds 0)`.
+
+If these conditions recur sufficiently often in later chapters, they may be given the
+project-specific names `IsBoundedVariable`, `IsUnboundedVariable`, and
+`IsInfinitesimalVariable`.
 
 New declarations are introduced here only when the notion used by the blueprint is genuinely
 project-specific or differs from the corresponding Mathlib notion.
@@ -57,14 +69,45 @@ abbrev IsOneBounded {ι β : Type*} [Norm β] (a : ι → β) : Prop :=
 -- Asymptotic Notation
 -- ===========================================================
 
-/-- X ≤ Y + o(1) in a strict sense:
-    There exists an infinitesimal sequence ε_i such that x_i ≤ y_i + ε_i eventually. -/
-def EventuallyLeUpToInfinitesimal (X Y : ℕ → ℝ) : Prop :=
-  ∃ ε : ℕ → ℝ, Tendsto ε atTop (nhds 0) ∧
-               (∀ᶠ i in atTop, X i ≤ Y i + ε i)
+/-- The one-sided asymptotic relation `X ≤ Y + o(1)` from the blueprint.
 
--- Notation shorthand
+It holds when there is a real error sequence tending to zero such that
+`X i ≤ Y i + err i` eventually. Equivalently, for every fixed `δ > 0`, one eventually has
+`X i ≤ Y i + δ`.
+
+This does not assert that `X - Y` tends to zero; it only requires the positive part of `X - Y`
+to tend to zero. -/
+def EventuallyLeUpToInfinitesimal (X Y : ℕ → ℝ) : Prop :=
+  ∃ err : ℕ → ℝ, Tendsto err atTop (nhds 0) ∧
+    ∀ᶠ i in atTop, X i ≤ Y i + err i
+
+/-- `X ≤o Y` denotes the complete blueprint expression `X ≤ Y + o(1)`; it is not the
+little-o relation `X = o(Y)`. -/
 notation X " ≤o " Y => EventuallyLeUpToInfinitesimal X Y
+
+/-- The relation `X ≤ Y + o(1)` is equivalent to `X i ≤ Y i + δ` eventually for every fixed
+positive `δ`. -/
+theorem eventuallyLeUpToInfinitesimal_iff_forall_pos (X Y : ℕ → ℝ) :
+    (X ≤o Y) ↔
+    ∀ δ : ℝ, 0 < δ → ∀ᶠ i in atTop, X i ≤ Y i + δ := by
+  constructor
+  · rintro ⟨err, herr, hXY⟩ δ hδ
+    rw [Metric.tendsto_nhds] at herr
+    have herr_small := herr δ hδ
+    filter_upwards [hXY, herr_small] with i hi hierr
+    rw [Real.dist_eq, sub_zero] at hierr
+    have herr_lt : err i < δ := lt_of_le_of_lt (le_abs_self _) hierr
+    linarith
+  · intro h
+    refine ⟨fun i => max (X i - Y i) 0, ?_, Filter.Eventually.of_forall fun i => ?_⟩
+    · rw [Metric.tendsto_nhds]
+      intro δ hδ
+      have hδ2 : 0 < δ / 2 := by linarith
+      filter_upwards [h (δ / 2) hδ2] with i hi
+      rw [Real.dist_eq, sub_zero, abs_of_nonneg (le_max_right _ _)]
+      exact max_lt (by linarith) hδ
+    · have hi : X i - Y i ≤ max (X i - Y i) 0 := le_max_left _ _
+      linarith
 
 -- ============================================================
 --  Auxiliary lemmas for subsequence extraction
@@ -142,37 +185,25 @@ private lemma build_increasing_thresholds
 -- Underspill Principle
 -- ===========================================================
 
-/-- Underspill Principle:
-    X ≤ Y + o(1)  ↔  For every constant ε > 0, X ≤ Y + ε + o(1) -/
+/-- **Underspill principle.** The relation `X ≤ Y + o(1)` holds if and only if
+`X ≤ Y + ε + o(1)` for every fixed `ε > 0`. -/
 theorem underspill (X Y : ℕ → ℝ) :
     (X ≤o Y) ↔
     (∀ ε : ℝ, ε > 0 → X ≤o (fun i => Y i + ε)) := by
   constructor
-  · intro ⟨εseq, hεseq_inf, hεseq_bound⟩ ε hε
-    refine ⟨εseq, hεseq_inf, ?_⟩
-    · filter_upwards [hεseq_bound] with i hi
-      linarith
+  · intro h ε hε
+    apply (eventuallyLeUpToInfinitesimal_iff_forall_pos X (fun i => Y i + ε)).2
+    intro δ hδ
+    filter_upwards [(eventuallyLeUpToInfinitesimal_iff_forall_pos X Y).1 h δ hδ] with i hi
+    linarith
   · intro h
-    have key : ∀ c : ℝ, c > 0 → ∀ᶠ i in atTop, X i - Y i < c := by
-      intro c hc
-      have hc2 : c / 2 > 0 := by linarith
-      obtain ⟨dseq, hdseq_inf, hdseq_bound⟩ := h (c / 2) hc2
-      rw [Metric.tendsto_nhds] at hdseq_inf
-      have hdseq_small := hdseq_inf (c / 2) hc2
-      filter_upwards [hdseq_bound, hdseq_small] with i hi_bound hi_small
-      rw [Real.dist_eq] at hi_small
-      simp at hi_small
-      have hdseq_lt : dseq i < c / 2 := lt_of_abs_lt hi_small
-      linarith
-    refine ⟨fun i => max (X i - Y i) 0, ?_, Filter.Eventually.of_forall fun i => ?_⟩
-    ·
-      rw [Metric.tendsto_nhds]
-      intro δ hδ
-      filter_upwards [key δ hδ] with i hi
-      rw [Real.dist_eq, sub_zero, abs_of_nonneg (le_max_right _ _)]
-      exact max_lt hi hδ
-    · have : X i - Y i ≤ max (X i - Y i) 0 := le_max_left _ _
-      linarith
+    apply (eventuallyLeUpToInfinitesimal_iff_forall_pos X Y).2
+    intro ε hε
+    have hε2 : 0 < ε / 2 := by linarith
+    have hbound := (eventuallyLeUpToInfinitesimal_iff_forall_pos
+      X (fun i => Y i + ε / 2)).1 (h (ε / 2) hε2) (ε / 2) hε2
+    filter_upwards [hbound] with i hi
+    linarith
 
 -- ============================================================
 -- Pointwise-bounded and pointwise-infinitesimal functions

--- a/expdb/basic.lean
+++ b/expdb/basic.lean
@@ -1,13 +1,26 @@
-/-
-  ANTEDB Blueprint -- Chapter 2: Basic Notation
-  ===============================================
--/
-
+import Mathlib.Analysis.Complex.Circle
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Analysis.Complex.Norm
 import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Order.Filter.Basic
 import Mathlib.Topology.MetricSpace.Sequences
+
+/-!
+# ANTEDB Blueprint — Chapter 2: Basic notation
+
+This file defines the project-specific notions used in Chapter 2. When a blueprint convention
+already has a standard Mathlib representation, later files use that representation directly:
+
+* the notation `e(θ)` is `𝐞 θ` after `open scoped FourierTransform`; it is coerced from
+  `Circle` to `ℂ` when the surrounding expression requires a complex number;
+* indicator functions are written using `Set.indicator`;
+* suprema and infima, including those of empty sets, use Mathlib's `sSup` and `sInf`;
+* finite cardinalities use `Finset.card`;
+* standard asymptotic relations use Mathlib's `Asymptotics` API.
+
+New declarations are introduced here only when the notion used by the blueprint is genuinely
+project-specific or differs from the corresponding Mathlib notion.
+-/
 
 open Filter Topology Real
 

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -1,11 +1,12 @@
 import expdb.basic
-import Mathlib.Analysis.Fourier.FourierTransform
 import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Distribution.FourierSchwartz
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.Tactic
 
 open MeasureTheory Real Complex Filter Topology BigOperators
+open scoped FourierTransform SchwartzMap ContDiff
 
 noncomputable section
 
@@ -76,6 +77,8 @@ lemma integral_pos (B : BumpData) : 0 < ∫ x : ℝ, B.ψ x := by
 
 end BumpData
 
+open BumpData
+
 -- ============================================================
 -- GOAL 1: WLOG ∑|aᵣ|² = 1
 -- "Let M = ∑|aᵣ|², let Aᵣ = aᵣ/M^{1/2} → ∑|Aᵣ|² = 1"
@@ -99,16 +102,35 @@ lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^
 -- ============================================================
 
 lemma psiHat_l2 (B : BumpData) :
-    ∫ u : ℝ, ‖psiHat B.ψ u‖ ^ 2 = 1 := by
-  -- Plancherel: ∫|ψ̂|² = ∫|ψ|²
-  have hP : ∫ u : ℝ, ‖psiHat B.ψ u‖ ^ 2 = ∫ x : ℝ, (B.ψ x) ^ 2 := by
-    simp only [psiHat]
-    rw [← MeasureTheory.integral_norm_sq_eq_integral_sq_norm_fourier]
-    · congr 1; ext u
-      congr 1; ext x
-      simp [e_def, Complex.norm_ofReal, norm_e]
-    · exact B.integrable.ofReal
-  rw [hP, B.l2norm]
+      ∫ u : ℝ, ‖psiHat B.ψ u‖ ^ 2 = 1 := by
+    have hcomp : HasCompactSupport (fun x : ℝ => (B.ψ x : ℂ)) :=
+      HasCompactSupport.of_support_subset_isCompact
+        (isCompact_Icc (a := -1 / 4) (b := 1 / 4)) (by
+          intro x hx
+          simp only [Function.mem_support] at hx
+          have h := B.supp x (by exact_mod_cast hx)
+          simp only [Set.mem_Icc, abs_le] at h ⊢
+          simpa only [neg_div] using h)
+
+    have hsmooth : ContDiff ℝ ∞ (fun x : ℝ => (B.ψ x : ℂ)) := by
+      simpa only [ContinuousLinearMap.coe_comp', Function.comp_apply,
+        Complex.ofRealCLM_apply] using
+        (Complex.ofRealCLM.contDiff (n := ∞)).comp
+          (B.smooth.of_le (by simp))
+
+    let f : 𝓢(ℝ, ℂ) := hcomp.toSchwartzMap hsmooth
+
+    have hfourier : (fun u : ℝ => psiHat B.ψ u) = 𝓕 (f : ℝ → ℂ) := by
+      funext u
+      rw [Real.fourier_real_eq]
+      simp [f, psiHat, e, Circle.smul_def, Real.fourierChar_apply]
+      apply integral_congr_ae
+      filter_upwards with x
+      ring
+
+    simp_rw [show psiHat B.ψ = 𝓕 (f : ℝ → ℂ) from hfourier]
+    rw [← SchwartzMap.fourier_coe, SchwartzMap.integral_norm_sq_fourier]
+    simpa [f, Real.norm_eq_abs, abs_of_nonneg (B.nonneg _)] using B.l2norm
 
 -- ============================================================
 -- ψ̂ is rapidly decaying

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -25,7 +25,7 @@ Proof structure:
   Goal 3: ∫_J |∑ aᵣ e(ξᵣ t)|² dt ≪ N for |J| = N       [eq 3.2]
   Goal 4: ∫_I F = T - ∫_ℝ F·E  (Fubini identity)
   Goal 5: E(t) ≪ (1 + dist(t,∂I)/N)^{-10}
-  Goal 6: ∫_ℝ F·E ≪ N  (dyadic decomposition)
+  Goal 6: ∫_ℝ F·E ≪ N  (integer-cell summation)
   Goal 7: Assembly → Lemma 3.1
 -/
 -- ============================================================
@@ -173,6 +173,13 @@ lemma psiHat_l2 : ∫ u : ℝ, ‖psiHat u‖ ^ 2 = 1 := by
   simp_rw [psiHat_eq_fourier]
   rw [← SchwartzMap.fourier_coe, SchwartzMap.integral_norm_sq_fourier]
   simpa [psiSchwartz, Real.norm_eq_abs, abs_of_nonneg (psi_nonneg _)] using psi_l2norm
+
+private lemma psiHat_sq_integrable :
+    Integrable (fun u : ℝ => ‖psiHat u‖ ^ 2) := by
+  by_contra h
+  have hzero := psiHat_l2
+  rw [integral_undef h] at hzero
+  norm_num at hzero
 
 -- ============================================================
 -- ψ̂ is rapidly decaying
@@ -454,12 +461,12 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- Goal 2 at scale M then gives c·∫_J F ≤ M ≪ψ N.
 -- ============================================================
 
-private theorem goal3_uniform {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ) :
-    ∃ C : ℝ, 0 < C ∧ ∀ a₀ : ℝ,
-    ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
+    ∃ C : ℝ, 0 < C ∧ ∀ j₀ : ℝ,
+    ∫ t in Set.Icc j₀ (j₀ + N), expSumSq a ξ t ≤ C * N := by
   obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound
   -- Enlarge the smoothing scale so that the whole interval lies in the
   -- neighbourhood on which `psiHat_lower_bound` applies.
@@ -477,10 +484,10 @@ private theorem goal3_uniform {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     apply (div_le_div_iff₀ hM hN).2
     simpa using hNM
   refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
-  intro a₀
-  set t₀ := a₀ + N / 2
+  intro j₀
+  set t₀ := j₀ + N / 2
   have h2 := goal2 a ξ M hM t₀ hnorm hsepM
-  have hlb_J : ∀ t ∈ Set.Icc a₀ (a₀ + N),
+  have hlb_J : ∀ t ∈ Set.Icc j₀ (j₀ + N),
       c ≤ ‖psiHat ((t - t₀) / M)‖ ^ 2 := by
     intro t ht
     apply hlb
@@ -503,11 +510,11 @@ private theorem goal3_uniform {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     by_contra h
     rw [integral_undef h] at h2
     linarith
-  have hFub : c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ M := by
-    calc c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t
-        = ∫ t in Set.Icc a₀ (a₀ + N), c * expSumSq a ξ t :=
+  have hFub : c * ∫ t in Set.Icc j₀ (j₀ + N), expSumSq a ξ t ≤ M := by
+    calc c * ∫ t in Set.Icc j₀ (j₀ + N), expSumSq a ξ t
+        = ∫ t in Set.Icc j₀ (j₀ + N), c * expSumSq a ξ t :=
             (integral_const_mul _ _).symm
-      _ ≤ ∫ t in Set.Icc a₀ (a₀ + N),
+      _ ≤ ∫ t in Set.Icc j₀ (j₀ + N),
             expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2 := by
           apply setIntegral_mono_on
           · exact (continuous_const.mul hFcont).integrableOn_Icc
@@ -528,16 +535,6 @@ private theorem goal3_uniform {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   apply (le_div_iff₀ hc).2
   nlinarith
 
-theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
-    (N : ℝ) (hN : 0 < N)
-    (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : IsSeparatedFamily (1 / N) ξ)
-    (a₀ : ℝ) :
-    ∃ C : ℝ, 0 < C ∧
-    ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
-  obtain ⟨C, hC, hlocal⟩ := goal3_uniform a ξ N hN hnorm hsep
-  exact ⟨C, hC, hlocal a₀⟩
-
 -- ============================================================
 -- GOAL 4: ∫_I F = T - ∫_ℝ F·E  (Fubini identity)
 --
@@ -549,15 +546,15 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- ============================================================
 
 -- E(t) = 1/N ∫_I |ψ̂((t-t₀)/N)|² dt₀ - 1_I(t)
-def kernelE (N : ℝ) (a₀ b₀ : ℝ) (t : ℝ) : ℝ :=
-  (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) -
-  Set.indicator (Set.Icc a₀ b₀) (fun _ => (1 : ℝ)) t
+def kernelE (N : ℝ) (left right : ℝ) (t : ℝ) : ℝ :=
+  (1 / N) * (∫ t₀ in Set.Icc left right, ‖psiHat ((t - t₀) / N)‖ ^ 2) -
+  Set.indicator (Set.Icc left right) (fun _ => (1 : ℝ)) t
 
 private lemma kernelAverage_eq_intervalIntegral (N : ℝ) (hN : 0 < N)
-    (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) (t : ℝ) :
-    (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) =
-    ∫ u in (t - b₀) / N..(t - a₀) / N, ‖psiHat u‖ ^ 2 := by
-  rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hab]
+    (left right : ℝ) (hleft_right : left ≤ right) (t : ℝ) :
+    (1 / N) * (∫ t₀ in Set.Icc left right, ‖psiHat ((t - t₀) / N)‖ ^ 2) =
+    ∫ u in (t - right) / N..(t - left) / N, ‖psiHat u‖ ^ 2 := by
+  rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hleft_right]
   have hchange : (fun t₀ : ℝ => ‖psiHat ((t - t₀) / N)‖ ^ 2) =
       fun t₀ => ‖psiHat (t / N - t₀ / N)‖ ^ 2 := by
     funext t₀
@@ -565,16 +562,16 @@ private lemma kernelAverage_eq_intervalIntegral (N : ℝ) (hN : 0 < N)
   rw [hchange]
   simpa only [one_div, smul_eq_mul] using
     (intervalIntegral.inv_smul_integral_comp_sub_div
-      (f := fun u : ℝ => ‖psiHat u‖ ^ 2) (a := a₀) (b := b₀) N (t / N)).trans (by
+      (f := fun u : ℝ => ‖psiHat u‖ ^ 2) (a := left) (b := right) N (t / N)).trans (by
         congr 1 <;> field_simp)
 
 theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ)
-    (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
-    ∫ t in Set.Icc a₀ b₀, expSumSq a ξ t =
-    T - ∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t := by
+    (left right : ℝ) (T : ℝ) (hT : T = right - left) (hleft_right : left ≤ right) :
+    ∫ t in Set.Icc left right, expSumSq a ξ t =
+    T - ∫ t : ℝ, expSumSq a ξ t * kernelE N left right t := by
   let F : ℝ → ℝ := expSumSq a ξ
   let K : ℝ → ℝ → ℝ := fun t₀ t => ‖psiHat ((t - t₀) / N)‖ ^ 2
   let H : ℝ × ℝ → ℝ := fun p => F p.2 * K p.1 p.2
@@ -606,7 +603,7 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     rw [integral_undef h] at hzero
     linarith
   -- The product-space integrability follows from the already evaluated slices.
-  have hH_int : Integrable H ((volume.restrict (Set.Icc a₀ b₀)).prod volume) := by
+  have hH_int : Integrable H ((volume.restrict (Set.Icc left right)).prod volume) := by
     apply (integrable_prod_iff hH_cont.aestronglyMeasurable).2
     constructor
     · exact ae_of_all _ hslice
@@ -619,46 +616,46 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       rw [hmarginal]
       exact integrableOn_const measure_Icc_lt_top.ne
   -- Integrate the constant marginal over t₀ ∈ I.
-  have hNT : ∫ _ in Set.Icc a₀ b₀, N = N * T := by
-    rw [setIntegral_const, Real.volume_real_Icc_of_le hab, smul_eq_mul, hT]
+  have hNT : ∫ _ in Set.Icc left right, N = N * T := by
+    rw [setIntegral_const, Real.volume_real_Icc_of_le hleft_right, smul_eq_mul, hT]
     ring
   -- Fubini, with the interval restriction built into the first measure.
   have hswap :
-      (∫ t₀ in Set.Icc a₀ b₀, ∫ t : ℝ, H (t₀, t)) =
-      ∫ t : ℝ, ∫ t₀ in Set.Icc a₀ b₀, H (t₀, t) := by
+      (∫ t₀ in Set.Icc left right, ∫ t : ℝ, H (t₀, t)) =
+      ∫ t : ℝ, ∫ t₀ in Set.Icc left right, H (t₀, t) := by
     exact integral_integral_swap hH_int
-  have hFubini : ∫ t : ℝ, F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t) = N * T := by
+  have hFubini : ∫ t : ℝ, F t * (∫ t₀ in Set.Icc left right, K t₀ t) = N * T := by
     calc
-      ∫ t : ℝ, F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t) =
-          ∫ t : ℝ, ∫ t₀ in Set.Icc a₀ b₀, H (t₀, t) := by
+      ∫ t : ℝ, F t * (∫ t₀ in Set.Icc left right, K t₀ t) =
+          ∫ t : ℝ, ∫ t₀ in Set.Icc left right, H (t₀, t) := by
             congr 1
             ext t
-            change F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t) =
-              ∫ t₀ in Set.Icc a₀ b₀, F t * K t₀ t
+            change F t * (∫ t₀ in Set.Icc left right, K t₀ t) =
+              ∫ t₀ in Set.Icc left right, F t * K t₀ t
             rw [integral_const_mul]
-      _ = ∫ t₀ in Set.Icc a₀ b₀, ∫ t : ℝ, H (t₀, t) := hswap.symm
-      _ = ∫ _ in Set.Icc a₀ b₀, N := by
+      _ = ∫ t₀ in Set.Icc left right, ∫ t : ℝ, H (t₀, t) := hswap.symm
+      _ = ∫ _ in Set.Icc left right, N := by
         apply setIntegral_congr_fun measurableSet_Icc
         intro t₀ _
         exact h31 t₀
       _ = N * T := hNT
   have hFK_int : Integrable (fun t : ℝ => F t *
-      (∫ t₀ in Set.Icc a₀ b₀, K t₀ t)) := by
+      (∫ t₀ in Set.Icc left right, K t₀ t)) := by
     have hmarginal := hH_int.integral_prod_right
     apply hmarginal.congr
     apply ae_of_all
     intro t
-    change (∫ t₀ in Set.Icc a₀ b₀, F t * K t₀ t) =
-      F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t)
+    change (∫ t₀ in Set.Icc left right, F t * K t₀ t) =
+      F t * (∫ t₀ in Set.Icc left right, K t₀ t)
     rw [integral_const_mul]
-  have hFI_int : Integrable ((Set.Icc a₀ b₀).indicator F) :=
+  have hFI_int : Integrable ((Set.Icc left right).indicator F) :=
     hF_cont.integrableOn_Icc.integrable_indicator measurableSet_Icc
-  have hexpand : (fun t : ℝ => expSumSq a ξ t * kernelE N a₀ b₀ t) =
-      fun t => (1 / N) * (F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t)) -
-        (Set.Icc a₀ b₀).indicator F t := by
+  have hexpand : (fun t : ℝ => expSumSq a ξ t * kernelE N left right t) =
+      fun t => (1 / N) * (F t * (∫ t₀ in Set.Icc left right, K t₀ t)) -
+        (Set.Icc left right).indicator F t := by
     funext t
     simp only [kernelE, F, K]
-    by_cases ht : t ∈ Set.Icc a₀ b₀
+    by_cases ht : t ∈ Set.Icc left right
     · rw [Set.indicator_of_mem ht, Set.indicator_of_mem ht]
       ring
     · rw [Set.indicator_of_notMem ht, Set.indicator_of_notMem ht]
@@ -673,24 +670,20 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --
 --   Step 1: ψ̂ rapidly decaying (IBP)
 --   Step 2: 1/N ∫_I |ψ̂((t-t₀)/N)|² dt₀ = ∫_{I_t} |ψ̂(u)|² du
---           where I_t = [(t-b₀)/N, (t-a₀)/N]
+--           where I_t = [(t - right)/N, (t - left)/N]
 --   Step 3 (t ∈ I): 0 ∈ I_t, so = 1 - ∫_{ℝ\I_t} |ψ̂|² ≪ (1+d_t)^{-10}
 --   Step 4 (t ∉ I): 0 ∉ I_t, so = ∫_{I_t} |ψ̂|² ≪ (1+d_t)^{-10}
 -- ============================================================
 
 theorem goal5 (N : ℝ) (hN : 0 < N)
-    (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
+    (left right : ℝ) (hleft_right : left ≤ right) :
     ∃ C : ℝ, 0 < C ∧ ∀ t : ℝ,
-    |kernelE N a₀ b₀ t| ≤
-    C * (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ)) := by
+    |kernelE N left right t| ≤
+    C * (1 + min (|t - left| / N) (|t - right| / N)) ^ (-(10 : ℝ)) := by
   let f : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
   have hf_nonneg : ∀ u, 0 ≤ f u := fun u => sq_nonneg _
   have hf_int : Integrable f := by
-    by_contra h
-    have hzero := psiHat_l2
-    change ∫ u : ℝ, f u = 1 at hzero
-    rw [integral_undef h] at hzero
-    norm_num at hzero
+    simpa only [f] using psiHat_sq_integrable
   obtain ⟨C₀, hC₀, hdecay⟩ := psiHat_decay 6
   let w : ℝ → ℝ := fun u => (1 + |u|) ^ (-(2 : ℝ))
   have hw_nonneg : ∀ u, 0 ≤ w u := fun u => Real.rpow_nonneg (by positivity) _
@@ -752,53 +745,53 @@ theorem goal5 (N : ℝ) (hN : 0 < N)
       _ = C * (1 + d) ^ (-(10 : ℝ)) := rfl
   refine ⟨C, hC, ?_⟩
   intro t
-  let Aₜ := (t - b₀) / N
-  let Bₜ := (t - a₀) / N
-  let d := min |Bₜ| |Aₜ|
-  have hAB : Aₜ ≤ Bₜ := by
-    dsimp [Aₜ, Bₜ]
-    exact div_le_div_of_nonneg_right (sub_le_sub_left hab t) hN.le
+  let uLower := (t - right) / N
+  let uUpper := (t - left) / N
+  let d := min |uUpper| |uLower|
+  have hLowerUpper : uLower ≤ uUpper := by
+    dsimp [uLower, uUpper]
+    exact div_le_div_of_nonneg_right (sub_le_sub_left hleft_right t) hN.le
   have hd : 0 ≤ d := le_min (abs_nonneg _) (abs_nonneg _)
-  have hsubst : (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) =
-      ∫ u in Set.Icc Aₜ Bₜ, f u := by
-    simpa only [f, Aₜ, Bₜ, intervalIntegral.integral_of_le hAB,
+  have hsubst : (1 / N) * (∫ t₀ in Set.Icc left right, f ((t - t₀) / N)) =
+      ∫ u in Set.Icc uLower uUpper, f u := by
+    simpa only [f, uLower, uUpper, intervalIntegral.integral_of_le hLowerUpper,
       integral_Icc_eq_integral_Ioc] using
-      kernelAverage_eq_intervalIntegral N hN a₀ b₀ hab t
-  have hd_eq : d = min (|t - a₀| / N) (|t - b₀| / N) := by
-    dsimp [d, Aₜ, Bₜ]
+      kernelAverage_eq_intervalIntegral N hN left right hleft_right t
+  have hd_eq : d = min (|t - left| / N) (|t - right| / N) := by
+    dsimp [d, uLower, uUpper]
     rw [abs_div, abs_div, abs_of_pos hN]
-  by_cases ht : t ∈ Set.Icc a₀ b₀
-  · have hAₜ : Aₜ ≤ 0 := by
-      dsimp [Aₜ]
+  by_cases ht : t ∈ Set.Icc left right
+  · have huLower_nonpos : uLower ≤ 0 := by
+      dsimp [uLower]
       exact div_nonpos_of_nonpos_of_nonneg (sub_nonpos.mpr ht.2) hN.le
-    have hBₜ : 0 ≤ Bₜ := by
-      dsimp [Bₜ]
+    have huUpper_nonneg : 0 ≤ uUpper := by
+      dsimp [uUpper]
       exact div_nonneg (sub_nonneg.mpr ht.1) hN.le
-    have hsubset : (Set.Icc Aₜ Bₜ)ᶜ ⊆ {u : ℝ | d ≤ |u|} := by
+    have hsubset : (Set.Icc uLower uUpper)ᶜ ⊆ {u : ℝ | d ≤ |u|} := by
       intro u hu
       simp only [Set.mem_compl_iff, Set.mem_Icc, not_and_or, not_le] at hu
       simp only [Set.mem_setOf_eq]
       rcases hu with hu | hu
-      · rw [abs_of_nonpos (hu.le.trans hAₜ)]
-        exact (min_le_right |Bₜ| |Aₜ|).trans (by
-          rw [abs_of_nonpos hAₜ]
+      · rw [abs_of_nonpos (hu.le.trans huLower_nonpos)]
+        exact (min_le_right |uUpper| |uLower|).trans (by
+          rw [abs_of_nonpos huLower_nonpos]
           linarith)
-      · rw [abs_of_nonneg (hBₜ.trans hu.le)]
-        exact (min_le_left |Bₜ| |Aₜ|).trans (by
-          rw [abs_of_nonneg hBₜ]
+      · rw [abs_of_nonneg (huUpper_nonneg.trans hu.le)]
+        exact (min_le_left |uUpper| |uLower|).trans (by
+          rw [abs_of_nonneg huUpper_nonneg]
           linarith)
-    have hcomp : (∫ u in Set.Icc Aₜ Bₜ, f u) - 1 =
-        -(∫ u in (Set.Icc Aₜ Bₜ)ᶜ, f u) := by
+    have hcomp : (∫ u in Set.Icc uLower uUpper, f u) - 1 =
+        -(∫ u in (Set.Icc uLower uUpper)ᶜ, f u) := by
       rw [setIntegral_compl measurableSet_Icc hf_int, psiHat_l2]
       ring
     rw [kernelE, Set.indicator_of_mem ht]
-    change |(1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) - 1| ≤ _
+    change |(1 / N) * (∫ t₀ in Set.Icc left right, f ((t - t₀) / N)) - 1| ≤ _
     rw [hsubst, hcomp, abs_neg, abs_of_nonneg
       (setIntegral_nonneg measurableSet_Icc.compl fun u _ => hf_nonneg u)]
     rw [← hd_eq]
     exact (setIntegral_mono_set hf_int.integrableOn (ae_of_all _ hf_nonneg)
       (ae_of_all _ hsubset)).trans (htail d hd)
-  · have hzero : (0 : ℝ) ∉ Set.Icc Aₜ Bₜ := by
+  · have hzero : (0 : ℝ) ∉ Set.Icc uLower uUpper := by
       intro h0
       apply ht
       constructor
@@ -810,64 +803,65 @@ theorem goal5 (N : ℝ) (hN : 0 < N)
         rcases div_nonpos_iff.mp h0.1 with h | h
         · exact (hN.not_ge h.2).elim
         · exact h.1
-    have hsubset : Set.Icc Aₜ Bₜ ⊆ {u : ℝ | d ≤ |u|} := by
+    have hsubset : Set.Icc uLower uUpper ⊆ {u : ℝ | d ≤ |u|} := by
       intro u hu
       rcases hu with ⟨hu1, hu2⟩
       simp only [Set.mem_setOf_eq]
-      have hzero' : 0 < Aₜ ∨ Bₜ < 0 := by
+      have hzero' : 0 < uLower ∨ uUpper < 0 := by
         simpa only [Set.mem_Icc, not_and_or, not_le] using hzero
-      rcases hzero' with hApos | hBneg
-      · rw [abs_of_nonneg (hApos.le.trans hu1)]
-        exact (min_le_right |Bₜ| |Aₜ|).trans (by
-          rw [abs_of_nonneg hApos.le]
+      rcases hzero' with hLowerPos | hUpperNeg
+      · rw [abs_of_nonneg (hLowerPos.le.trans hu1)]
+        exact (min_le_right |uUpper| |uLower|).trans (by
+          rw [abs_of_nonneg hLowerPos.le]
           linarith)
-      · rw [abs_of_nonpos (hu2.trans hBneg.le)]
-        exact (min_le_left |Bₜ| |Aₜ|).trans (by
-          rw [abs_of_nonpos hBneg.le]
+      · rw [abs_of_nonpos (hu2.trans hUpperNeg.le)]
+        exact (min_le_left |uUpper| |uLower|).trans (by
+          rw [abs_of_nonpos hUpperNeg.le]
           linarith)
     rw [kernelE, Set.indicator_of_notMem ht]
-    change |(1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) - 0| ≤ _
+    change |(1 / N) * (∫ t₀ in Set.Icc left right, f ((t - t₀) / N)) - 0| ≤ _
     rw [sub_zero, hsubst, abs_of_nonneg
       (setIntegral_nonneg measurableSet_Icc fun u _ => hf_nonneg u)]
     rw [← hd_eq]
     exact (setIntegral_mono_set hf_int.integrableOn (ae_of_all _ hf_nonneg)
       (ae_of_all _ hsubset)).trans (htail d hd)
 
-private lemma kernelE_aestronglyMeasurable (N : ℝ) (hN : 0 < N)
-    (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
-    AEStronglyMeasurable (kernelE N a₀ b₀) := by
+private lemma kernelAverage_continuous (N : ℝ) (hN : 0 < N)
+    (left right : ℝ) (hleft_right : left ≤ right) :
+    Continuous (fun t : ℝ =>
+      (1 / N) * (∫ t₀ in Set.Icc left right, ‖psiHat ((t - t₀) / N)‖ ^ 2)) := by
   let f : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
   have hf_int : Integrable f := by
-    by_contra h
-    have hzero := psiHat_l2
-    change ∫ u : ℝ, f u = 1 at hzero
-    rw [integral_undef h] at hzero
-    norm_num at hzero
+    simpa only [f] using psiHat_sq_integrable
   let P : ℝ → ℝ := fun x => ∫ u in 0..x, f u
   have hP_cont : Continuous P :=
     intervalIntegral.continuous_primitive (fun x y => hf_int.intervalIntegrable) 0
   have havg : (fun t : ℝ =>
-      (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2)) =
-      fun t => P ((t - a₀) / N) - P ((t - b₀) / N) := by
+      (1 / N) * (∫ t₀ in Set.Icc left right, ‖psiHat ((t - t₀) / N)‖ ^ 2)) =
+      fun t => P ((t - left) / N) - P ((t - right) / N) := by
     funext t
-    rw [kernelAverage_eq_intervalIntegral N hN a₀ b₀ hab t]
+    rw [kernelAverage_eq_intervalIntegral N hN left right hleft_right t]
     dsimp [P]
     exact (intervalIntegral.integral_interval_sub_left
       hf_int.intervalIntegrable hf_int.intervalIntegrable).symm
-  have havg_cont : Continuous (fun t : ℝ =>
-      (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2)) := by
-    rw [havg]
-    exact (hP_cont.comp ((continuous_id.sub continuous_const).div_const N)).sub
-      (hP_cont.comp ((continuous_id.sub continuous_const).div_const N))
+  rw [havg]
+  exact (hP_cont.comp ((continuous_id.sub continuous_const).div_const N)).sub
+    (hP_cont.comp ((continuous_id.sub continuous_const).div_const N))
+
+private lemma kernelE_aestronglyMeasurable (N : ℝ) (hN : 0 < N)
+    (left right : ℝ) (hleft_right : left ≤ right) :
+    AEStronglyMeasurable (kernelE N left right) := by
   have hind_meas : AEStronglyMeasurable
-      (Set.indicator (Set.Icc a₀ b₀) (fun _ => (1 : ℝ))) :=
+      (Set.indicator (Set.Icc left right) (fun _ => (1 : ℝ))) :=
     (Measurable.indicator measurable_const measurableSet_Icc).aestronglyMeasurable
-  exact havg_cont.aestronglyMeasurable.sub hind_meas
+  exact (kernelAverage_continuous N hN left right hleft_right).aestronglyMeasurable.sub
+    hind_meas
 
 -- ============================================================
 -- GOAL 6: ∫_ℝ F·E ≪ N  (integer-cell summation)
 --
--- Partition ℝ into intervals [c+kN,c+(k+1)N), k ∈ ℤ.  Goal 3 gives a
+-- Partition ℝ into intervals [c + kN, c + (k+1)N), k ∈ ℤ.
+-- Goal 3 gives a
 -- uniform O(N) bound on every cell, while Goal 5 contributes a summable
 -- shifted p-series in k.  Apply this once at each endpoint of I.
 -- ============================================================
@@ -876,17 +870,17 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ)
-    (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
+    (left right : ℝ) (hleft_right : left ≤ right) :
     ∃ C : ℝ, 0 < C ∧
-    |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t| ≤ C * N := by
+    |∫ t : ℝ, expSumSq a ξ t * kernelE N left right t| ≤ C * N := by
   let F : ℝ → ℝ := expSumSq a ξ
   have hF_nonneg : ∀ t, 0 ≤ F t := fun t => sq_nonneg _
   have hF_cont : Continuous F := by
     dsimp [F]
     unfold expSumSq expSum e
     fun_prop
-  obtain ⟨C₃, hC₃, hlocal⟩ := goal3_uniform a ξ N hN hnorm hsep
-  obtain ⟨C₅, hC₅, hE⟩ := goal5 N hN a₀ b₀ hab
+  obtain ⟨C₃, hC₃, hlocal⟩ := goal3 a ξ N hN hnorm hsep
+  obtain ⟨C₅, hC₅, hE⟩ := goal5 N hN left right hleft_right
   let weight : ℝ → ℝ → ℝ :=
     fun c t => (1 + |t - c| / N) ^ (-(10 : ℝ))
   have hweight_nonneg : ∀ c t, 0 ≤ weight c t :=
@@ -962,12 +956,12 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   have hcell_bound : ∀ c k,
       ∫ t in cell c k, W c t ≤ b k * (C₃ * N) := by
     intro c k
-    let s := c + k • N
-    have hend : c + (k + 1) • N = s + N := by
-      dsimp [s]
+    let cellLeft := c + k • N
+    have hend : c + (k + 1) • N = cellLeft + N := by
+      dsimp [cellLeft]
       rw [add_smul, one_smul]
       ring
-    have hcell_eq : cell c k = Set.Ico s (s + N) := by
+    have hcell_eq : cell c k = Set.Ico cellLeft (cellLeft + N) := by
       dsimp [cell]
       rw [hend]
     have hWcell : IntegrableOn (W c) (cell c k) :=
@@ -979,7 +973,7 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
         rw [hcell_eq]
         exact Set.Ico_subset_Icc_self)
     have hFcell :
-        ∫ t in cell c k, F t ≤ ∫ t in Set.Icc s (s + N), F t := by
+        ∫ t in cell c k, F t ≤ ∫ t in Set.Icc cellLeft (cellLeft + N), F t := by
       apply setIntegral_mono_set hF_cont.integrableOn_Icc
         (ae_of_all _ fun t => hF_nonneg t)
       apply ae_of_all
@@ -995,10 +989,10 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
             mul_le_mul_of_nonneg_left (hcell_weight c k t ht) (hF_nonneg t)
           _ = b k * F t := by ring
       _ = b k * ∫ t in cell c k, F t := integral_const_mul _ _
-      _ ≤ b k * ∫ t in Set.Icc s (s + N), F t :=
+      _ ≤ b k * ∫ t in Set.Icc cellLeft (cellLeft + N), F t :=
         mul_le_mul_of_nonneg_left hFcell (hb_nonneg k)
       _ ≤ b k * (C₃ * N) :=
-        mul_le_mul_of_nonneg_left (hlocal s) (hb_nonneg k)
+        mul_le_mul_of_nonneg_left (hlocal cellLeft) (hb_nonneg k)
   have hW : ∀ c, Integrable (W c) ∧ ∫ t : ℝ, W c t ≤ B * (C₃ * N) := by
     intro c
     have hcell_int : ∀ k, IntegrableOn (W c) (cell c k) := by
@@ -1039,10 +1033,10 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       _ = B * (C₃ * N) := by
         exact hb_summable.tsum_mul_right (C₃ * N)
   have hmin_split : ∀ t,
-      (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ)) ≤
-      weight a₀ t + weight b₀ t := by
+      (1 + min (|t - left| / N) (|t - right| / N)) ^ (-(10 : ℝ)) ≤
+      weight left t + weight right t := by
     intro t
-    rcases le_total (|t - a₀| / N) (|t - b₀| / N) with h | h
+    rcases le_total (|t - left| / N) (|t - right| / N) with h | h
     · rw [min_eq_left h]
       dsimp [weight]
       exact le_add_of_nonneg_right (Real.rpow_nonneg (by positivity) _)
@@ -1050,58 +1044,58 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       dsimp [weight]
       exact le_add_of_nonneg_left (Real.rpow_nonneg (by positivity) _)
   have hmajor : ∀ t,
-      F t * |kernelE N a₀ b₀ t| ≤ C₅ * (W a₀ t + W b₀ t) := by
+      F t * |kernelE N left right t| ≤ C₅ * (W left t + W right t) := by
     intro t
     calc
-      F t * |kernelE N a₀ b₀ t| ≤
-          F t * (C₅ * (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ))) :=
+      F t * |kernelE N left right t| ≤
+          F t * (C₅ * (1 + min (|t - left| / N) (|t - right| / N)) ^ (-(10 : ℝ))) :=
         mul_le_mul_of_nonneg_left (hE t) (hF_nonneg t)
-      _ ≤ F t * (C₅ * (weight a₀ t + weight b₀ t)) :=
+      _ ≤ F t * (C₅ * (weight left t + weight right t)) :=
         mul_le_mul_of_nonneg_left
           (mul_le_mul_of_nonneg_left (hmin_split t) hC₅.le) (hF_nonneg t)
-      _ = C₅ * (W a₀ t + W b₀ t) := by
+      _ = C₅ * (W left t + W right t) := by
         dsimp [W]
         ring
-  have hW_a := hW a₀
-  have hW_b := hW b₀
-  have hmajor_int : Integrable (fun t => C₅ * (W a₀ t + W b₀ t)) :=
-    (hW_a.1.add hW_b.1).const_mul C₅
-  have hkernel_meas := kernelE_aestronglyMeasurable N hN a₀ b₀ hab
+  have hWLeft := hW left
+  have hWRight := hW right
+  have hmajor_int : Integrable (fun t => C₅ * (W left t + W right t)) :=
+    (hWLeft.1.add hWRight.1).const_mul C₅
+  have hkernel_meas := kernelE_aestronglyMeasurable N hN left right hleft_right
   have hkernel_abs_meas : AEStronglyMeasurable
-      (fun t => |kernelE N a₀ b₀ t|) := by
+      (fun t => |kernelE N left right t|) := by
     simpa only [Real.norm_eq_abs] using hkernel_meas.norm
   have hFEabs_meas : AEStronglyMeasurable
-      (fun t => F t * |kernelE N a₀ b₀ t|) :=
+      (fun t => F t * |kernelE N left right t|) :=
     hF_cont.aestronglyMeasurable.mul hkernel_abs_meas
-  have hFEabs : Integrable (fun t => F t * |kernelE N a₀ b₀ t|) := by
+  have hFEabs : Integrable (fun t => F t * |kernelE N left right t|) := by
     apply hmajor_int.mono' hFEabs_meas
     filter_upwards with t
     rw [Real.norm_eq_abs, abs_of_nonneg
       (mul_nonneg (hF_nonneg t) (abs_nonneg _))]
     exact hmajor t
-  have hFE : Integrable (fun t => F t * kernelE N a₀ b₀ t) := by
+  have hFE : Integrable (fun t => F t * kernelE N left right t) := by
     apply hFEabs.mono' (hF_cont.aestronglyMeasurable.mul hkernel_meas)
     filter_upwards with t
-    change |F t * kernelE N a₀ b₀ t| ≤ F t * |kernelE N a₀ b₀ t|
+    change |F t * kernelE N left right t| ≤ F t * |kernelE N left right t|
     rw [abs_mul, abs_of_nonneg (hF_nonneg t)]
   refine ⟨2 * C₅ * C₃ * (B + 1), by positivity, ?_⟩
   calc
-    |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t| =
-        |∫ t : ℝ, F t * kernelE N a₀ b₀ t| := by rfl
-    _ ≤ ∫ t : ℝ, |F t * kernelE N a₀ b₀ t| :=
+    |∫ t : ℝ, expSumSq a ξ t * kernelE N left right t| =
+        |∫ t : ℝ, F t * kernelE N left right t| := by rfl
+    _ ≤ ∫ t : ℝ, |F t * kernelE N left right t| :=
       abs_integral_le_integral_abs
-    _ = ∫ t : ℝ, F t * |kernelE N a₀ b₀ t| := by
+    _ = ∫ t : ℝ, F t * |kernelE N left right t| := by
       congr 1
       funext t
       rw [abs_mul, abs_of_nonneg (hF_nonneg t)]
-    _ ≤ ∫ t : ℝ, C₅ * (W a₀ t + W b₀ t) :=
+    _ ≤ ∫ t : ℝ, C₅ * (W left t + W right t) :=
       integral_mono hFEabs hmajor_int hmajor
-    _ = C₅ * ((∫ t : ℝ, W a₀ t) + ∫ t : ℝ, W b₀ t) := by
-      rw [integral_const_mul, integral_add hW_a.1 hW_b.1]
+    _ = C₅ * ((∫ t : ℝ, W left t) + ∫ t : ℝ, W right t) := by
+      rw [integral_const_mul, integral_add hWLeft.1 hWRight.1]
     _ ≤ C₅ * (B * (C₃ * N) + B * (C₃ * N)) := by
       gcongr
-      · exact hW_a.2
-      · exact hW_b.2
+      · exact hWLeft.2
+      · exact hWRight.2
     _ ≤ 2 * C₅ * C₃ * (B + 1) * N := by
       calc
         C₅ * (B * (C₃ * N) + B * (C₃ * N)) = (2 * C₅ * C₃ * N) * B := by ring
@@ -1120,9 +1114,9 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- ============================================================
 theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (hsep : IsSeparatedFamily (1 / N) ξ)
-    (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
+    (left right : ℝ) (T : ℝ) (hT : T = right - left) (hleft_right : left ≤ right) :
     ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
-    ∫ t in Set.Icc a₀ b₀, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
+    ∫ t in Set.Icc left right, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2 := by
   set M := ∑ r, ‖a r‖ ^ 2
   -- Trivial case: M = 0 → all aᵣ = 0
@@ -1158,12 +1152,12 @@ theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       rw [this, norm_mul, Complex.norm_ofReal,
           abs_of_nonneg (Real.sqrt_nonneg M), mul_pow, Real.sq_sqrt hMpos.le]
     -- Apply Goal 4 to get the Fubini identity
-    have h4 := goal4 A ξ N hN hAnorm hsep a₀ b₀ T hT hab
+    have h4 := goal4 A ξ N hN hAnorm hsep left right T hT hleft_right
     -- Apply Goal 6 to bound the error
-    obtain ⟨C, hC, h6⟩ := goal6 A ξ N hN hAnorm hsep a₀ b₀ hab
+    obtain ⟨C, hC, h6⟩ := goal6 A ξ N hN hAnorm hsep left right hleft_right
     -- ∫_I ‖expSum A‖² = T - err,  |err| ≤ C·N
-    set err := ∫ t : ℝ, expSumSq A ξ t * kernelE N a₀ b₀ t
-    have hA_eq : ∫ t in Set.Icc a₀ b₀, expSumSq A ξ t = T - err := by
+    set err := ∫ t : ℝ, expSumSq A ξ t * kernelE N left right t
+    have hA_eq : ∫ t in Set.Icc left right, expSumSq A ξ t = T - err := by
       simp [expSumSq] at h4 ⊢; exact h4
     have herr_bd : |err| ≤ C * N := by
       simp [expSumSq] at h6; exact h6
@@ -1173,7 +1167,7 @@ theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       rw [abs_div, abs_neg, abs_of_pos hN]
       exact div_le_of_le_mul₀ hN.le (by positivity) (by linarith)
     · -- ∫_I ‖expSum a‖² = (T + θN) · M
-      have ha_int : ∫ t in Set.Icc a₀ b₀, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
+      have ha_int : ∫ t in Set.Icc left right, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
           M * (T - err) := by
         conv_lhs => ext t; rw [hrescale t]
         rw [integral_const_mul]

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -397,7 +397,7 @@ private lemma scaled_psiHat_l2 (N t₀ : ℝ) (hN : 0 < N) :
     simp only [H, F]
     congr 2
     field_simp
-    ring
+    ring_nf
   rw [hrewrite, Measure.integral_comp_mul_left H (1 / N)]
   rw [show (∫ y : ℝ, H y) = ∫ y : ℝ, F y by
     exact integral_add_right_eq_self F (-t₀ / N)]
@@ -418,7 +418,7 @@ private lemma scaled_psiHat_sq_integrable (N t₀ : ℝ) (hN : 0 < N) :
   ext t
   congr 2
   field_simp
-  ring
+  ring_nf
 
 private lemma scaled_phase_integrable (q N t₀ : ℝ) (hN : 0 < N) :
     Integrable (fun t : ℝ =>
@@ -463,7 +463,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       _ = a r * (starRingEnd ℂ) (a s) * e ((ξ r - ξ s) * t) := by
         rw [← e_add]
         congr 1
-        ring
+        ring_nf
   have hBint (r s : Fin R) : Integrable (B r s) := by
     convert (scaled_phase_integrable (ξ r - ξ s) N t₀ hN).const_mul
       (a r * starRingEnd ℂ (a s)) using 1

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -1,5 +1,6 @@
 import expdb.basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.BumpFunction.InnerProduct
 import Mathlib.Analysis.Distribution.FourierSchwartz
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
@@ -25,59 +26,91 @@ Proof structure:
   Goal 7: Assembly → Lemma 3.1
 -/
 -- ============================================================
--- BumpData: ψ smooth, supported on [-1/4,1/4], L²-norm = 1
--- ψ(t) ≥ 0 (from handwritten proof: "we can choose ψ s.t. ψ(t) ≥ 0")
+-- A fixed smooth bump ψ, supported on [-1/4, 1/4], with L²-norm 1.
 -- ============================================================
 
-structure BumpData where
-  ψ       : ℝ → ℝ
-  smooth  : ContDiff ℝ ⊤ ψ
-  supp    : ∀ x, ψ x ≠ 0 → |x| ≤ 1 / 4
-  nonneg  : ∀ x, 0 ≤ ψ x
-  l2norm  : ∫ x : ℝ, (ψ x) ^ 2 = 1
+private def rawBump : ContDiffBump (0 : ℝ) :=
+  ⟨1 / 8, 1 / 4, by norm_num, by norm_num⟩
 
-namespace BumpData
+private def rawL2 : ℝ := ∫ x : ℝ, (rawBump x) ^ 2
 
--- ψ has compact support
-lemma hasCompactSupport (B : BumpData) : HasCompactSupport B.ψ :=
-  HasCompactSupport.of_support_subset_isCompact
-    (isCompact_Icc (a := -1 / 4) (b := 1 / 4))
-    (fun x hx => by
-      simp only [Function.mem_support] at hx
-      have h := B.supp x hx
-      simp only [Set.mem_Icc, abs_le] at h ⊢
-      simpa only [neg_div] using h)
+private lemma rawL2_pos : 0 < rawL2 := by
+  apply integral_pos_of_integrable_nonneg_nonzero (x := 0)
+  · simpa using ((rawBump.contDiff (n := ⊤)).continuous.pow 2)
+  · apply ((rawBump.contDiff (n := ⊤)).continuous.pow 2).integrable_of_hasCompactSupport
+    apply HasCompactSupport.of_support_subset_isCompact rawBump.hasCompactSupport.isCompact
+    simpa only [Function.support_pow rawBump (by norm_num : 2 ≠ 0)] using
+      (subset_tsupport (rawBump : ℝ → ℝ))
+  · intro x
+    positivity
+  · have hzero : (rawBump : ℝ → ℝ) 0 = 1 := by
+      apply rawBump.one_of_mem_closedBall
+      simp [rawBump, Metric.mem_closedBall]
+    simp [hzero]
+
+def ψ (x : ℝ) : ℝ := rawBump x / Real.sqrt rawL2
+
+lemma psi_smooth : ContDiff ℝ ∞ ψ := by
+  simpa [ψ] using (rawBump.contDiff (n := ⊤)).div_const (Real.sqrt rawL2)
+
+lemma psi_hasCompactSupport : HasCompactSupport ψ := by
+  apply HasCompactSupport.of_support_subset_isCompact rawBump.hasCompactSupport.isCompact
+  intro x hx
+  apply subset_tsupport rawBump
+  simp only [Function.mem_support] at hx ⊢
+  intro hzero
+  apply hx
+  simp [ψ, hzero]
+
+lemma psi_supp (x : ℝ) (hx : ψ x ≠ 0) : |x| ≤ 1 / 4 := by
+  have hraw : (rawBump : ℝ → ℝ) x ≠ 0 := by
+    intro hzero
+    apply hx
+    simp [ψ, hzero]
+  have hmem : x ∈ Metric.ball (0 : ℝ) rawBump.rOut := by
+    rw [← rawBump.support_eq]
+    exact hraw
+  have : |x| < 1 / 4 := by
+    simpa [rawBump, Metric.mem_ball, Real.dist_eq] using hmem
+  exact this.le
+
+lemma psi_nonneg (x : ℝ) : 0 ≤ ψ x :=
+  div_nonneg (rawBump.nonneg' x) (Real.sqrt_nonneg rawL2)
+
+lemma psi_l2norm : ∫ x : ℝ, (ψ x) ^ 2 = 1 := by
+  rw [show (fun x : ℝ => (ψ x) ^ 2) = fun x => (rawBump x) ^ 2 / rawL2 by
+        funext x
+        simp only [ψ, div_pow]
+        rw [Real.sq_sqrt rawL2_pos.le]]
+  rw [integral_div]
+  exact div_self (ne_of_gt rawL2_pos)
 
 -- ψ̂(u) = ∫_ℝ ψ(x) e(-xu) dx
-def psiHat (ψ : ℝ → ℝ) (u : ℝ) : ℂ :=
+def psiHat (u : ℝ) : ℂ :=
   ∫ x : ℝ, (ψ x : ℂ) * e (-(x * u))
 
 -- ψ is integrable
-lemma integrable (B : BumpData) : Integrable B.ψ :=
-  B.smooth.continuous.integrable_of_hasCompactSupport B.hasCompactSupport
+lemma psi_integrable : Integrable ψ :=
+  psi_smooth.continuous.integrable_of_hasCompactSupport psi_hasCompactSupport
 
 -- ∫ ψ > 0  (from proof: "ψ(t) ≥ 0 and ‖ψ‖_{L²} = 1 so ψ ≢ 0")
-lemma integral_pos (B : BumpData) : 0 < ∫ x : ℝ, B.ψ x := by
-  have hne : ∃ x, B.ψ x ≠ 0 := by
+lemma psi_integral_pos : 0 < ∫ x : ℝ, ψ x := by
+  have hne : ∃ x, ψ x ≠ 0 := by
     by_contra h
     push_neg at h
-    have hsquare : ∫ x : ℝ, (B.ψ x) ^ 2 = 0 := by
+    have hsquare : ∫ x : ℝ, (ψ x) ^ 2 = 0 := by
       calc
-        ∫ x : ℝ, (B.ψ x) ^ 2
+        ∫ x : ℝ, (ψ x) ^ 2
             = ∫ x : ℝ, (0 : ℝ) ^ 2 := by
               congr 1
               ext x
               rw [h x]
         _ = 0 := by simp
-    linarith [B.l2norm, hsquare]
+    linarith [psi_l2norm, hsquare]
 
   obtain ⟨x, hx⟩ := hne
   exact integral_pos_of_integrable_nonneg_nonzero
-    B.smooth.continuous B.integrable B.nonneg hx
-
-end BumpData
-
-open BumpData
+    psi_smooth.continuous psi_integrable psi_nonneg hx
 
 -- ============================================================
 -- GOAL 1: WLOG ∑|aᵣ|² = 1
@@ -101,36 +134,34 @@ lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^
 --             = N ∫|ψ̂(u)|² du = N  (by Plancherel, ‖ψ‖=1)"
 -- ============================================================
 
-lemma psiHat_l2 (B : BumpData) :
-      ∫ u : ℝ, ‖psiHat B.ψ u‖ ^ 2 = 1 := by
-    have hcomp : HasCompactSupport (fun x : ℝ => (B.ψ x : ℂ)) :=
-      HasCompactSupport.of_support_subset_isCompact
-        (isCompact_Icc (a := -1 / 4) (b := 1 / 4)) (by
-          intro x hx
-          simp only [Function.mem_support] at hx
-          have h := B.supp x (by exact_mod_cast hx)
-          simp only [Set.mem_Icc, abs_le] at h ⊢
-          simpa only [neg_div] using h)
+private lemma psi_complex_hasCompactSupport : HasCompactSupport (fun x : ℝ => (ψ x : ℂ)) :=
+  HasCompactSupport.of_support_subset_isCompact
+    (isCompact_Icc (a := -1 / 4) (b := 1 / 4)) (by
+      intro x hx
+      simp only [Function.mem_support] at hx
+      have h := psi_supp x (by exact_mod_cast hx)
+      simp only [Set.mem_Icc, abs_le] at h ⊢
+      simpa only [neg_div] using h)
 
-    have hsmooth : ContDiff ℝ ∞ (fun x : ℝ => (B.ψ x : ℂ)) := by
-      simpa only [ContinuousLinearMap.coe_comp', Function.comp_apply,
-        Complex.ofRealCLM_apply] using
-        (Complex.ofRealCLM.contDiff (n := ∞)).comp
-          (B.smooth.of_le (by simp))
+private lemma psi_complex_smooth : ContDiff ℝ ∞ (fun x : ℝ => (ψ x : ℂ)) := by
+  simpa only [ContinuousLinearMap.coe_comp', Function.comp_apply, Complex.ofRealCLM_apply] using
+    (Complex.ofRealCLM.contDiff (n := ∞)).comp psi_smooth
 
-    let f : 𝓢(ℝ, ℂ) := hcomp.toSchwartzMap hsmooth
+private def psiSchwartz : 𝓢(ℝ, ℂ) :=
+  psi_complex_hasCompactSupport.toSchwartzMap psi_complex_smooth
 
-    have hfourier : (fun u : ℝ => psiHat B.ψ u) = 𝓕 (f : ℝ → ℂ) := by
-      funext u
-      rw [Real.fourier_real_eq]
-      simp [f, psiHat, e, Circle.smul_def, Real.fourierChar_apply]
-      apply integral_congr_ae
-      filter_upwards with x
-      ring
+private lemma psiHat_eq_fourier : psiHat = 𝓕 (psiSchwartz : ℝ → ℂ) := by
+  funext u
+  rw [Real.fourier_real_eq]
+  simp [psiSchwartz, psiHat, e, Circle.smul_def, Real.fourierChar_apply]
+  apply integral_congr_ae
+  filter_upwards with x
+  ring
 
-    simp_rw [show psiHat B.ψ = 𝓕 (f : ℝ → ℂ) from hfourier]
-    rw [← SchwartzMap.fourier_coe, SchwartzMap.integral_norm_sq_fourier]
-    simpa [f, Real.norm_eq_abs, abs_of_nonneg (B.nonneg _)] using B.l2norm
+lemma psiHat_l2 : ∫ u : ℝ, ‖psiHat u‖ ^ 2 = 1 := by
+  simp_rw [psiHat_eq_fourier]
+  rw [← SchwartzMap.fourier_coe, SchwartzMap.integral_norm_sq_fourier]
+  simpa [psiSchwartz, Real.norm_eq_abs, abs_of_nonneg (psi_nonneg _)] using psi_l2norm
 
 -- ============================================================
 -- ψ̂ is rapidly decaying
@@ -138,71 +169,32 @@ lemma psiHat_l2 (B : BumpData) :
 -- "ψ̂(u) = 1/(2πiu) ψ̂'(u), repeat k times → |ψ̂(u)| ≪ Cₖ/(1+|u|)ᵏ"
 -- ============================================================
 
-lemma psiHat_decay (B : BumpData) (K : ℕ) :
-    ∃ C : ℝ, 0 < C ∧ ∀ u : ℝ, ‖psiHat B.ψ u‖ ≤ C * (1 + |u|) ^ (-(K : ℝ)) := by
-  induction K with
-  | zero =>
-    -- K=0: |ψ̂(u)| ≤ ∫|ψ| (trivial bound)
-    refine ⟨∫ x : ℝ, |B.ψ x|, by
-      apply integral_pos_of_ne_zero_of_nonneg (fun x => abs_nonneg _)
-      intro h; have : ∫ x : ℝ, (B.ψ x)^2 = 0 := by
-        calc ∫ x : ℝ, (B.ψ x)^2
-            = ∫ x : ℝ, (0:ℝ)^2 := by
-              congr 1; ext x
-              have := congr_fun h x; simp [abs_eq_zero] at this
-              rw [this]
-          _ = 0 := by simp
-      linarith [B.l2norm], ?_⟩
+lemma psiHat_decay (K : ℕ) :
+    ∃ C : ℝ, 0 < C ∧ ∀ u : ℝ, ‖psiHat u‖ ≤ C * (1 + |u|) ^ (-(K : ℝ)) := by
+  let g : 𝓢(ℝ, ℂ) := 𝓕 psiSchwartz
+  have hfourier : ∀ u : ℝ, psiHat u = g u := by
     intro u
-    simp only [Nat.cast_zero, neg_zero, Real.rpow_zero, mul_one]
-    calc ‖psiHat B.ψ u‖
-        ≤ ∫ x : ℝ, ‖(B.ψ x : ℂ) * e (-(x * u))‖ :=
-          norm_integral_le_integral_norm _
-      _ = ∫ x : ℝ, |B.ψ x| := by
-          congr 1; ext x
-          simp [norm_e, Complex.norm_ofReal]
-  | succ k ih =>
-    -- K → K+1: use IBP: ψ̂(u) = 1/(2πiu) \widehat{ψ'}(u)
-    obtain ⟨C, hC, hk⟩ := ih
-    -- apply IBP to get the derivative bound
-    refine ⟨C / (2 * π), by positivity, ?_⟩
-    intro u
-    by_cases hu : u = 0
-    · subst hu; simp
-      calc ‖psiHat B.ψ 0‖
-          ≤ ∫ x : ℝ, |B.ψ x| :=
-            norm_integral_le_integral_norm _ |>.trans (by
-              congr 1; ext x; simp [norm_e, Complex.norm_ofReal])
-        _ ≤ _ := by positivity
-    · -- IBP: ψ̂(u) = 1/(2πiu) \widehat{ψ'}(u)
-      have hIBP : psiHat B.ψ u =
-          (1 / (2 * π * Complex.I * u)) * psiHat (deriv B.ψ) u := by
-        simp [psiHat, e_def]
-        rw [← integral_mul_left]
-        apply integral_congr_ae
-        apply ae_of_all
-        intro x
-        -- Integration by parts (compact support → boundary terms vanish)
-        field_simp
-        ring
-      rw [hIBP, norm_mul]
-      have hnorm_coeff : ‖(1 : ℂ) / (2 * π * Complex.I * u)‖ = 1 / (2 * π * |u|) := by
-        simp [Complex.norm_div, Complex.norm_mul, Complex.norm_ofReal,
-              Complex.norm_I, abs_of_pos Real.pi_pos]
-        field_simp
-      rw [hnorm_coeff]
-      calc 1 / (2 * π * |u|) * ‖psiHat (deriv B.ψ) u‖
-          ≤ 1 / (2 * π * |u|) * (C * (1 + |u|) ^ (-(k : ℝ))) :=
-            mul_le_mul_of_nonneg_left (hk u) (by positivity)
-        _ = C / (2 * π) * ((1 + |u|) ^ (-(k : ℝ)) / |u|) := by ring
-        _ ≤ C / (2 * π) * (1 + |u|) ^ (-((k : ℝ) + 1)) := by
-            apply mul_le_mul_of_nonneg_left _ (by positivity)
-            -- (1+|u|)^{-k} / |u| ≤ (1+|u|)^{-(k+1)}
-            rw [Real.rpow_add (by linarith [abs_pos.mpr hu])]
-            apply div_le_iff_le_mul (abs_pos.mpr hu) |>.mpr
-            rw [← mul_assoc, Real.rpow_neg_one]
-            apply mul_le_mul_of_nonneg_right _ (by positivity)
-            linarith [le_abs_self u]
+    exact congr_fun psiHat_eq_fourier u
+  let c : ℝ := 2 ^ K * (Finset.Iic (K, 0)).sup
+    (fun m => SchwartzMap.seminorm ℝ m.1 m.2) g
+  refine ⟨|c| + 1, by positivity, ?_⟩
+  intro u
+  have hweight : (1 + |u|) ^ K * ‖psiHat u‖ ≤ c := by
+    have hw := SchwartzMap.one_add_le_sup_seminorm_apply
+      (𝕜 := ℝ) (m := (K, 0)) (k := K) (n := 0) le_rfl le_rfl g u
+    rw [norm_iteratedFDeriv_zero, ← hfourier u] at hw
+    simpa [c, Real.norm_eq_abs] using hw
+  have hbase : 0 < 1 + |u| := by positivity
+  have hpow : 0 < (1 + |u|) ^ K := by positivity
+  have hrpow : (1 + |u|) ^ (-(K : ℝ)) = ((1 + |u|) ^ K)⁻¹ := by
+    rw [← Real.rpow_natCast, Real.rpow_neg hbase.le]
+  rw [hrpow, ← div_eq_mul_inv]
+  apply (le_div_iff₀ hpow).2
+  calc
+    ‖psiHat u‖ * (1 + |u|) ^ K =
+        (1 + |u|) ^ K * ‖psiHat u‖ := by ring
+    _ ≤ c := hweight
+    _ ≤ |c| + 1 := by linarith [le_abs_self c]
 
 -- ============================================================
 -- ψ̂ has positive lower bound near 0
@@ -211,41 +203,43 @@ lemma psiHat_decay (B : BumpData) (K : ℕ) :
 --  → ψ̂(u) > ψ̂(0)/2 for |u| < δ → |ψ̂(u)|² ≥ c·1_{[-δ/2,δ/2]}(u)"
 -- ============================================================
 
-lemma psiHat_lower_bound (B : BumpData) :
+lemma psiHat_lower_bound :
     ∃ c δ : ℝ, 0 < c ∧ 0 < δ ∧
-    ∀ u : ℝ, |u| ≤ δ → c ≤ ‖psiHat B.ψ u‖ ^ 2 := by
-  -- Step 1: ψ̂ is continuous (proved from differentiability in notes)
-  have hcts : Continuous (psiHat B.ψ) := by
-    apply continuous_of_dominated
-    · intro u
-      exact ((B.smooth.continuous.ofReal.mul (continuous_const)).integral_comp_right)
-    · exact fun u x => by simp [norm_e, Complex.norm_ofReal, abs_le]
-    · exact B.integrable.norm
-    · exact measurable_const
-  -- Step 2: ψ̂(0) = ∫ψ > 0
-  have hpsi0 : 0 < (psiHat B.ψ 0).re := by
-    have : (psiHat B.ψ 0).re = ∫ x : ℝ, B.ψ x := by
-      simp [psiHat, e_def, Complex.ofReal_re]
-    rw [this]; exact B.integral_pos
-  -- Step 3: By continuity, choose δ with ψ̂(u) > ψ̂(0)/2 for |u| < δ
-  have hpos : 0 < ‖psiHat B.ψ 0‖ := by
-    rw [Complex.norm_pos_iff]
-    intro h; simp [h] at hpsi0
-  set v₀ := ‖psiHat B.ψ 0‖
-  obtain ⟨δ, hδ, hball⟩ := (hcts.continuousAt (x := 0)).eventually
-    (Ioo_mem_nhds (by linarith : v₀/2 < v₀) (by linarith : v₀ < v₀ + 1)) |>.exists
-  -- c = (v₀/2)², δ as above
-  refine ⟨(v₀ / 2) ^ 2, δ, by positivity, hδ, ?_⟩
+    ∀ u : ℝ, |u| ≤ δ → c ≤ ‖psiHat u‖ ^ 2 := by
+  have hcts : Continuous psiHat := by
+    rw [psiHat_eq_fourier]
+    exact (𝓕 psiSchwartz).continuous
+  have hpsi0_eq : (psiHat 0).re = ∫ x : ℝ, ψ x := by
+    simp only [psiHat, mul_zero, neg_zero, e_zero, mul_one]
+    have hψc : Integrable (fun x : ℝ => (ψ x : ℂ)) := psi_integrable.ofReal
+    simpa using (integral_re hψc).symm
+  have hpsi0 : 0 < (psiHat 0).re := by
+    rw [hpsi0_eq]
+    exact psi_integral_pos
+  have hpos : 0 < ‖psiHat 0‖ := by
+    rw [norm_pos_iff]
+    intro hzero
+    have : (psiHat 0).re = 0 := by rw [hzero]; rfl
+    linarith
+  set v₀ := ‖psiHat 0‖
+  obtain ⟨δ, hδ, hball⟩ :=
+    (Metric.continuousAt_iff.mp hcts.continuousAt) (v₀ / 2) (by linarith)
+  refine ⟨(v₀ / 2) ^ 2, δ / 2, by positivity, by positivity, ?_⟩
   intro u hu
-  have hball' : ‖psiHat B.ψ u‖ > v₀ / 2 := by
-    have hdist : dist (psiHat B.ψ u) (psiHat B.ψ 0) < v₀ / 2 := by
-      apply hball
-      simp [Real.dist_eq, abs_lt]
-      exact ⟨by linarith [neg_abs_le u, hu], by linarith [le_abs_self u, hu]⟩
-    have := norm_sub_norm_le (psiHat B.ψ 0) (psiHat B.ψ u)
-    rw [Real.dist_eq] at hdist
-    linarith [abs_sub_comm ‖psiHat B.ψ 0‖ ‖psiHat B.ψ u‖ ▸ hdist]
-  nlinarith [norm_nonneg (psiHat B.ψ u)]
+  have hdist : dist (psiHat u) (psiHat 0) < v₀ / 2 := by
+    apply hball
+    rw [Real.dist_eq]
+    simp only [sub_zero]
+    exact lt_of_le_of_lt hu (by linarith)
+  have hbound : v₀ - ‖psiHat u‖ < v₀ / 2 := by
+    calc
+      v₀ - ‖psiHat u‖ = ‖psiHat 0‖ - ‖psiHat u‖ := rfl
+      _ ≤ ‖psiHat 0 - psiHat u‖ := norm_sub_norm_le _ _
+      _ = dist (psiHat u) (psiHat 0) := by
+        rw [dist_eq_norm_sub, norm_sub_rev]
+      _ < v₀ / 2 := hdist
+  have hball' : v₀ / 2 < ‖psiHat u‖ := by linarith
+  nlinarith [norm_nonneg (psiHat u)]
 
 -- ============================================================
 -- GOAL 2: ∫_ℝ F(t) |ψ̂((t-t₀)/N)|² dt = N   [equation (3.1)]
@@ -256,11 +250,11 @@ lemma psiHat_lower_bound (B : BumpData) :
 --                        forces |q|≤1/(2N), contradiction)
 -- ============================================================
 
-theorem goal2 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (t₀ : ℝ)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : Separated N ξ) :
-    ∫ t : ℝ, expSumSq a ξ t * ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 = N := by
+    ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
   simp only [expSumSq]
   -- Expand |∑ aᵣ e(ξᵣt)|² = ∑ᵣ ∑ₛ aᵣ·ā_s·e((ξᵣ-ξₛ)t)
   have hexpand : ∀ t : ℝ,
@@ -299,9 +293,9 @@ theorem goal2 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
         rw [show ∑ r : Fin R, ‖a r‖ ^ 2 = (1 : ℝ) from hnorm]
       rw [one_mul]
       -- Substitute u = (t-t₀)/N: ∫|ψ̂((t-t₀)/N)|² dt = N·∫|ψ̂(u)|² du = N
-      have : ∫ t : ℝ, ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 = N := by
-        rw [show (fun t => ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2) =
-            fun t => ‖psiHat B.ψ ((1/N) * t + (-t₀/N))‖ ^ 2 from by
+      have : ∫ t : ℝ, ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
+        rw [show (fun t => ‖psiHat ((t - t₀) / N)‖ ^ 2) =
+            fun t => ‖psiHat ((1/N) * t + (-t₀/N))‖ ^ 2 from by
           ext t; congr 2; field_simp; ring]
         rw [integral_comp_mul_add _ (1/N) (-t₀/N) (by simp [hN.ne'])]
         simp [abs_of_pos (by positivity : (0:ℝ) < 1/N)]
@@ -325,17 +319,17 @@ theorem goal2 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       set q := ξ r - ξ s
       have hq : |q| ≥ 1 / N := hsep r s hs.2
       -- Key: ∫ ψ(v)ψ(v-qN) dv = 0 when |qN| > 1/2
-      have hconv : ∫ v : ℝ, B.ψ v * B.ψ (v - q * N) = 0 := by
+      have hconv : ∫ v : ℝ, ψ v * ψ (v - q * N) = 0 := by
         apply integral_eq_zero_of_forall_eq_zero
         intro v
-        by_cases h1 : B.ψ v = 0
+        by_cases h1 : ψ v = 0
         · simp [h1]
-        · by_cases h2 : B.ψ (v - q * N) = 0
+        · by_cases h2 : ψ (v - q * N) = 0
           · simp [h2]
           · exfalso
             -- |v| ≤ 1/4 and |v - qN| ≤ 1/4 → |qN| ≤ 1/2
-            have hv := B.supp v h1
-            have hvq := B.supp (v - q * N) h2
+            have hv := psi_supp v h1
+            have hvq := psi_supp (v - q * N) h2
             have hcontra : |q * N| ≤ 1/2 := by
               calc |q * N| = |v - (v - q * N)| := by ring_nf
                 _ ≤ |v| + |v - q * N| := abs_sub_abs_le_abs_sub _ _
@@ -364,7 +358,7 @@ theorem goal2 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --   Step 3: N ≥ c · ∫_{J_{t₀}} F dt → ∫_J F ≪ N/c ≪ N
 -- ============================================================
 
-theorem goal3 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : Separated N ξ)
@@ -372,15 +366,15 @@ theorem goal3 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     ∃ C : ℝ, 0 < C ∧
     ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
   -- Get lower bound c for |ψ̂|² near 0
-  obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound B
+  obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound
   -- Choose t₀ = center of J
   set t₀ := a₀ + N / 2
   -- From Goal 2: N = ∫_ℝ F|ψ̂((t-t₀)/N)|² dt
-  have h2 := goal2 B a ξ N hN t₀ hnorm hsep
+  have h2 := goal2 a ξ N hN t₀ hnorm hsep
   -- On J = [a₀, a₀+N]: |(t-t₀)/N| ≤ 1/2
   -- If δ ≥ 1/2, then |ψ̂((t-t₀)/N)|² ≥ c on J
   have hlb_J : ∀ t ∈ Set.Icc a₀ (a₀ + N),
-      c ≤ ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 := by
+      c ≤ ‖psiHat ((t - t₀) / N)‖ ^ 2 := by
     intro t ht
     apply hlb
     simp only [t₀, abs_le, div_le_iff hN, neg_mul, le_div_iff hN]
@@ -392,7 +386,7 @@ theorem goal3 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
         = ∫ t in Set.Icc a₀ (a₀ + N), c * expSumSq a ξ t :=
             (integral_const_mul _ _).symm
       _ ≤ ∫ t in Set.Icc a₀ (a₀ + N),
-            expSumSq a ξ t * ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 := by
+            expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 := by
           apply set_integral_mono_ae
           · exact (measurable_const.mul (by measurability)).aestronglyMeasurable
           · exact (by measurability).aestronglyMeasurable
@@ -401,7 +395,7 @@ theorem goal3 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
             · exact mul_le_mul_of_nonneg_left (hlb_J t ht)
                 (by simp [expSumSq]; positivity)
             · simp
-      _ ≤ ∫ t : ℝ, expSumSq a ξ t * ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 :=
+      _ ≤ ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 :=
           set_integral_le_integral _
             (fun t => mul_nonneg (by simp [expSumSq]; positivity) (sq_nonneg _))
       _ = N := h2
@@ -419,37 +413,37 @@ theorem goal3 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- ============================================================
 
 -- E(t) = 1/N ∫_I |ψ̂((t-t₀)/N)|² dt₀ - 1_I(t)
-def kernelE (B : BumpData) (N : ℝ) (a₀ b₀ : ℝ) (t : ℝ) : ℝ :=
-  (1 / N) * ∫ t₀ in Set.Icc a₀ b₀, ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 -
+def kernelE (N : ℝ) (a₀ b₀ : ℝ) (t : ℝ) : ℝ :=
+  (1 / N) * ∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2 -
   Set.indicator (Set.Icc a₀ b₀) (fun _ => (1 : ℝ)) t
 
-theorem goal4 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : Separated N ξ)
     (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
     ∫ t in Set.Icc a₀ b₀, expSumSq a ξ t =
-    T - ∫ t : ℝ, expSumSq a ξ t * kernelE B N a₀ b₀ t := by
+    T - ∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t := by
   -- From (3.1): ∫_ℝ F(t)|ψ̂((t-t₀)/N)|² dt = N for each t₀
   have h31 : ∀ t₀ : ℝ,
-      ∫ t : ℝ, expSumSq a ξ t * ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 = N :=
-    goal2 B a ξ N hN · hnorm hsep
+      ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N :=
+    fun t₀ => goal2 a ξ N hN t₀ hnorm hsep
   -- Integrate over t₀ ∈ I: ∫_I N dt₀ = NT
   have hNT : ∫ _ in Set.Icc a₀ b₀, N = N * T := by
     simp [Real.volume_Icc, hT, abs_of_nonneg (by linarith)]
   -- Fubini: NT = ∫_ℝ F(t)(∫_I |ψ̂((t-t₀)/N)|² dt₀) dt
   have hFubini : ∫ t : ℝ, expSumSq a ξ t *
-      (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2) = N * T := by
+      (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) = N * T := by
     rw [← hNT, ← integral_integral_swap]
     · congr 1; ext t₀; exact h31 t₀
     · -- Fubini condition: F ⊗ |ψ̂|² is integrable
       apply Integrable.mono
         (f := fun p : ℝ × ℝ => (Finset.card (Finset.univ : Finset (Fin R)) : ℝ)^2 *
-          ‖psiHat B.ψ ((p.1 - p.2) / N)‖^2)
+          ‖psiHat ((p.1 - p.2) / N)‖^2)
       · apply Integrable.const_mul
         apply Integrable.comp_sub_right
         apply Integrable.comp_div_right
-        exact (psiHat_decay B 2).choose_spec.2 |>.integrable_of_hasCompactSupport
+        exact (psiHat_decay 2).choose_spec.2 |>.integrable_of_hasCompactSupport
           (HasCompactSupport.of_support_subset_isCompact (isCompact_Icc)
             (fun u _ => Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩))
       · apply ae_of_all; intro ⟨t, t₀⟩
@@ -468,7 +462,7 @@ theorem goal4 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   -- Rearrange: ∫_I F = T - ∫_ℝ F·E
   have hrearrange :
       ∫ t in Set.Icc a₀ b₀, expSumSq a ξ t =
-      T - ∫ t : ℝ, expSumSq a ξ t * kernelE B N a₀ b₀ t := by
+      T - ∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t := by
     simp only [kernelE]
     -- ∫ F·(1/N ∫_I |ψ̂|² - 1_I) = 1/N ∫ F(∫_I |ψ̂|²) - ∫_I F
     rw [integral_sub]
@@ -489,15 +483,15 @@ theorem goal4 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --   Step 4 (t ∉ I): 0 ∉ I_t, so = ∫_{I_t} |ψ̂|² ≪ (1+d_t)^{-10}
 -- ============================================================
 
-theorem goal5 (B : BumpData) (N : ℝ) (hN : 0 < N)
+theorem goal5 (N : ℝ) (hN : 0 < N)
     (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
     ∃ C : ℝ, 0 < C ∧ ∀ t : ℝ,
-    |kernelE B N a₀ b₀ t| ≤
+    |kernelE N a₀ b₀ t| ≤
     C * (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ)) := by
-  obtain ⟨C_d, hC_d, hdecay⟩ := psiHat_decay B 12
+  obtain ⟨C_d, hC_d, hdecay⟩ := psiHat_decay 12
   refine ⟨C_d ^ 2 * 8, by positivity, ?_⟩
   intro t
-have hint : Integrable (fun u => ‖psiHat B.ψ u‖ ^ 2) := by
+have hint : Integrable (fun u => ‖psiHat u‖ ^ 2) := by
     apply Integrable.mono (f := fun u => C_d * (1 + |u|)^(-(12:ℝ)))
     · apply Integrable.const_mul
       exact integrable_rpow_neg (by norm_num)
@@ -508,26 +502,26 @@ have hint : Integrable (fun u => ‖psiHat B.ψ u‖ ^ 2) := by
   -- Step 2: Substitution u = (t-t₀)/N
   -- 1/N ∫_I |ψ̂((t-t₀)/N)|² dt₀ = ∫_{I_t} |ψ̂(u)|² du
   have hsubst : (1 / N) * ∫ t₀ in Set.Icc a₀ b₀,
-      ‖psiHat B.ψ ((t - t₀) / N)‖ ^ 2 =
+      ‖psiHat ((t - t₀) / N)‖ ^ 2 =
       ∫ u in Set.Icc ((t - b₀) / N) ((t - a₀) / N),
-        ‖psiHat B.ψ u‖ ^ 2 := by
+        ‖psiHat u‖ ^ 2 := by
     rw [one_div, ← intervalIntegral.integral_comp_sub_left
-      (fun u => ‖psiHat B.ψ u‖ ^ 2) t]
+      (fun u => ‖psiHat u‖ ^ 2) t]
     simp [Set.uIcc_of_le (div_le_div_of_nonneg_right (by linarith) hN)]
     congr 1 <;> [field_simp; field_simp; ring]
   -- Tail bound: ∫_{|u|≥d} |ψ̂|² ≤ 2C²/(11(1+d)^{11}) ≪ (1+d)^{-10}
   have htail : ∀ d : ℝ, 0 ≤ d →
-      ∫ u in {u : ℝ | d ≤ |u|}, ‖psiHat B.ψ u‖ ^ 2 ≤
+      ∫ u in {u : ℝ | d ≤ |u|}, ‖psiHat u‖ ^ 2 ≤
       C_d ^ 2 * 8 * (1 + d) ^ (-(10 : ℝ)) := by
     intro d hd
-    calc ∫ u in {u | d ≤ |u|}, ‖psiHat B.ψ u‖ ^ 2
+    calc ∫ u in {u | d ≤ |u|}, ‖psiHat u‖ ^ 2
         ≤ C_d ^ 2 * ∫ u in {u | d ≤ |u|}, (1 + |u|) ^ (-(12 : ℝ)) := by
           apply set_integral_mono_ae
           · exact hint
           · exact (Integrable.const_mul hint2_)
           · apply ae_of_all; intro u
             have := hdecay u
-            nlinarith [norm_nonneg (psiHat B.ψ u), sq_nonneg (‖psiHat B.ψ u‖)]
+            nlinarith [norm_nonneg (psiHat u), sq_nonneg (‖psiHat u‖)]
       -- ∫_{|u|≥d} (1+|u|)^{-12} du = 2/(11(1+d)^{11})
       _ ≤ C_d ^ 2 * (8 * (1 + d) ^ (-(10 : ℝ))) := by
           apply mul_le_mul_of_nonneg_left _ (by positivity)
@@ -575,14 +569,14 @@ have hint : Integrable (fun u => ‖psiHat B.ψ u‖ ^ 2) := by
       · apply div_nonpos_of_nonpos_of_nonneg <;> linarith [htI.2]
       · apply div_nonneg <;> linarith [htI.1]
     -- ∫_{I_t} = ∫_ℝ - ∫_{ℝ\I_t} = 1 - ∫_{ℝ\I_t}
-    rw [psiHat_l2 B |>.symm]
+    rw [psiHat_l2.symm]
     rw [← integral_add_compl measurableSet_Icc (by sorry)]
     simp only [add_sub_cancel_left]
     rw [abs_neg]
-    calc |∫ u in (Set.Icc _ _)ᶜ, ‖psiHat B.ψ u‖^2|
-        ≤ ∫ u in (Set.Icc _ _)ᶜ, ‖psiHat B.ψ u‖^2 :=
+    calc |∫ u in (Set.Icc _ _)ᶜ, ‖psiHat u‖^2|
+        ≤ ∫ u in (Set.Icc _ _)ᶜ, ‖psiHat u‖^2 :=
           le_abs_self _
-      _ ≤ ∫ u in {u | d_t ≤ |u|}, ‖psiHat B.ψ u‖^2 := by
+      _ ≤ ∫ u in {u | d_t ≤ |u|}, ‖psiHat u‖^2 := by
           apply set_integral_mono_set
           · exact fun u => sq_nonneg _
           -- ℝ\I_t ⊆ {|u| ≥ d_t} because 0 ∈ I_t
@@ -614,8 +608,8 @@ have hint : Integrable (fun u => ‖psiHat B.ψ u‖ ^ 2) := by
       cases Set.not_mem_Icc.mp htI with
       | inl h => right; apply div_pos_of_neg_of_neg <;> linarith
       | inr h => left; apply div_neg_of_pos_of_neg <;> linarith
-    calc ∫ u in Set.Icc ((t-b₀)/N) ((t-a₀)/N), ‖psiHat B.ψ u‖^2
-        ≤ ∫ u in {u | d_t ≤ |u|}, ‖psiHat B.ψ u‖^2 := by
+    calc ∫ u in Set.Icc ((t-b₀)/N) ((t-a₀)/N), ‖psiHat u‖^2
+        ≤ ∫ u in {u | d_t ≤ |u|}, ‖psiHat u‖^2 := by
           apply set_integral_mono_set
           · exact fun u => sq_nonneg _
           -- I_t ⊆ {|u| ≥ d_t} because 0 ∉ I_t
@@ -654,22 +648,22 @@ have hint : Integrable (fun u => ‖psiHat B.ψ u‖ ^ 2) := by
 --   Case 2 (T ≪ N): direct application of (3.2)
 -- ============================================================
 
-theorem goal6 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : Separated N ξ)
     (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
     ∃ C : ℝ, 0 < C ∧
-    |∫ t : ℝ, expSumSq a ξ t * kernelE B N a₀ b₀ t| ≤ C * N := by
+    |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t| ≤ C * N := by
   set T := b₀ - a₀
-  obtain ⟨C₃, hC₃, hG3⟩ := goal3 B a ξ N hN hnorm hsep a₀
-  obtain ⟨C₅, hC₅, hG5⟩ := goal5 B N hN a₀ b₀ hab
+  obtain ⟨C₃, hC₃, hG3⟩ := goal3 a ξ N hN hnorm hsep a₀
+  obtain ⟨C₅, hC₅, hG5⟩ := goal5 N hN a₀ b₀ hab
   -- Case 2: T ≤ N (I fits inside one interval J)
   by_cases hTN : T ≤ N
   · -- Direct application of Goal 3
     refine ⟨C₃ * C₅, by positivity, ?_⟩
-    calc |∫ t : ℝ, expSumSq a ξ t * kernelE B N a₀ b₀ t|
-        ≤ ∫ t : ℝ, expSumSq a ξ t * |kernelE B N a₀ b₀ t| := by
+    calc |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t|
+        ≤ ∫ t : ℝ, expSumSq a ξ t * |kernelE N a₀ b₀ t| := by
           apply (abs_integral_le_integral_abs _).trans
           apply integral_mono_ae
           · sorry; · sorry
@@ -707,15 +701,15 @@ theorem goal6 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     -- Sum over layers: ∑_{ℓ=0}^{L} 2^{ℓ+1} · C₃N · C₅·(2^ℓ)^{-10}
     --                = 2C₃C₅N ∑_{ℓ=0}^{L} 2^{-9ℓ}
     --                ≤ 2C₃C₅N · 1/(1-2^{-9})
-    calc |∫ t : ℝ, expSumSq a ξ t * kernelE B N a₀ b₀ t|
+    calc |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t|
         ≤ ∑ ℓ in Finset.range (L + 1),
             ∑ k in Finset.range (2^(ℓ+1)),
             |∫ t in Set.Icc (a₀ - (k+1) * N) (a₀ - k * N),
-              expSumSq a ξ t * kernelE B N a₀ b₀ t| +
+              expSumSq a ξ t * kernelE N a₀ b₀ t| +
           ∑ ℓ in Finset.range (L + 1),
             ∑ k in Finset.range (2^(ℓ+1)),
             |∫ t in Set.Icc (b₀ + k * N) (b₀ + (k+1) * N),
-              expSumSq a ξ t * kernelE B N a₀ b₀ t| := by
+              expSumSq a ξ t * kernelE N a₀ b₀ t| := by
           sorry -- partition ℝ into layers
       _ ≤ ∑ ℓ in Finset.range (L + 1), (2^(ℓ+1) : ℝ) * (C₃ * N) *
             (C₅ * (2^ℓ)^(-(10:ℝ))) +
@@ -767,7 +761,7 @@ theorem goal6 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --              = (T + O(N)) · ∑|aᵣ|²  (by Goal 1: WLOG)
 -- ============================================================
 
-theorem lemma3_1 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (hsep : Separated N ξ)
     (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
     ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
@@ -807,11 +801,11 @@ theorem lemma3_1 (B : BumpData) {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → �
       rw [this, norm_mul, Complex.norm_ofReal,
           abs_of_nonneg (Real.sqrt_nonneg M), mul_pow, Real.sq_sqrt hMpos.le]
     -- Apply Goal 4 to get the Fubini identity
-    have h4 := goal4 B A ξ N hN hAnorm hsep a₀ b₀ T hT hab
+    have h4 := goal4 A ξ N hN hAnorm hsep a₀ b₀ T hT hab
     -- Apply Goal 6 to bound the error
-    obtain ⟨C, hC, h6⟩ := goal6 B A ξ N hN hAnorm hsep a₀ b₀ hab
+    obtain ⟨C, hC, h6⟩ := goal6 A ξ N hN hAnorm hsep a₀ b₀ hab
     -- ∫_I ‖expSum A‖² = T - err,  |err| ≤ C·N
-    set err := ∫ t : ℝ, expSumSq A ξ t * kernelE B N a₀ b₀ t
+    set err := ∫ t : ℝ, expSumSq A ξ t * kernelE N a₀ b₀ t
     have hA_eq : ∫ t in Set.Icc a₀ b₀, expSumSq A ξ t = T - err := by
       simp [expSumSq] at h4 ⊢; exact h4
     have herr_bd : |err| ≤ C * N := by

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -538,7 +538,7 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 
 -- E(t) = 1/N ∫_I |ψ̂((t-t₀)/N)|² dt₀ - 1_I(t)
 def kernelE (N : ℝ) (a₀ b₀ : ℝ) (t : ℝ) : ℝ :=
-  (1 / N) * ∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2 -
+  (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) -
   Set.indicator (Set.Icc a₀ b₀) (fun _ => (1 : ℝ)) t
 
 theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
@@ -548,54 +548,98 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
     ∫ t in Set.Icc a₀ b₀, expSumSq a ξ t =
     T - ∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t := by
-  -- From (3.1): ∫_ℝ F(t)|ψ̂((t-t₀)/N)|² dt = N for each t₀
+  let F : ℝ → ℝ := expSumSq a ξ
+  let K : ℝ → ℝ → ℝ := fun t₀ t => ‖psiHat ((t - t₀) / N)‖ ^ 2
+  let H : ℝ × ℝ → ℝ := fun p => F p.2 * K p.1 p.2
+  have hF_nonneg : ∀ t, 0 ≤ F t := fun t => sq_nonneg _
+  have hK_nonneg : ∀ t₀ t, 0 ≤ K t₀ t := fun t₀ t => sq_nonneg _
+  have hH_nonneg : ∀ p, 0 ≤ H p := fun p =>
+    mul_nonneg (hF_nonneg p.2) (hK_nonneg p.1 p.2)
+  have hF_cont : Continuous F := by
+    dsimp [F]
+    unfold expSumSq expSum e
+    fun_prop
+  have hpsiHat_cont : Continuous psiHat := by
+    rw [psiHat_eq_fourier]
+    exact (𝓕 psiSchwartz).continuous
+  have hK_cont : Continuous (fun p : ℝ × ℝ => K p.1 p.2) := by
+    exact ((hpsiHat_cont.comp
+      ((continuous_snd.sub continuous_fst).div_const N)).norm.pow 2)
+  have hH_cont : Continuous H :=
+    (hF_cont.comp continuous_snd).mul hK_cont
+  -- From (3.1): ∫_ℝ F(t)|ψ̂((t-t₀)/N)|² dt = N for each t₀.
   have h31 : ∀ t₀ : ℝ,
-      ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N :=
-    fun t₀ => goal2 a ξ N hN t₀ hnorm hsep
-  -- Integrate over t₀ ∈ I: ∫_I N dt₀ = NT
+      ∫ t : ℝ, H (t₀, t) = N := by
+    intro t₀
+    simpa only [H, F, K] using goal2 a ξ N hN t₀ hnorm hsep
+  have hslice : ∀ t₀ : ℝ, Integrable (fun t => H (t₀, t)) := by
+    intro t₀
+    by_contra h
+    have hzero := h31 t₀
+    rw [integral_undef h] at hzero
+    linarith
+  -- The product-space integrability follows from the already evaluated slices.
+  have hH_int : Integrable H ((volume.restrict (Set.Icc a₀ b₀)).prod volume) := by
+    apply (integrable_prod_iff hH_cont.aestronglyMeasurable).2
+    constructor
+    · exact ae_of_all _ hslice
+    · have hmarginal : (fun t₀ : ℝ => ∫ t : ℝ, ‖H (t₀, t)‖) = fun _ => N := by
+        funext t₀
+        rw [show (fun t : ℝ => ‖H (t₀, t)‖) = fun t => H (t₀, t) by
+          funext t
+          exact Real.norm_of_nonneg (hH_nonneg (t₀, t))]
+        exact h31 t₀
+      rw [hmarginal]
+      exact integrableOn_const measure_Icc_lt_top.ne
+  -- Integrate the constant marginal over t₀ ∈ I.
   have hNT : ∫ _ in Set.Icc a₀ b₀, N = N * T := by
-    simp [Real.volume_Icc, hT, abs_of_nonneg (by linarith)]
-  -- Fubini: NT = ∫_ℝ F(t)(∫_I |ψ̂((t-t₀)/N)|² dt₀) dt
-  have hFubini : ∫ t : ℝ, expSumSq a ξ t *
-      (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) = N * T := by
-    rw [← hNT, ← integral_integral_swap]
-    · congr 1; ext t₀; exact h31 t₀
-    · -- Fubini condition: F ⊗ |ψ̂|² is integrable
-      apply Integrable.mono
-        (f := fun p : ℝ × ℝ => (Finset.card (Finset.univ : Finset (Fin R)) : ℝ)^2 *
-          ‖psiHat ((p.1 - p.2) / N)‖^2)
-      · apply Integrable.const_mul
-        apply Integrable.comp_sub_right
-        apply Integrable.comp_div_right
-        exact (psiHat_decay 2).choose_spec.2 |>.integrable_of_hasCompactSupport
-          (HasCompactSupport.of_support_subset_isCompact (isCompact_Icc)
-            (fun u _ => Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩))
-      · apply ae_of_all; intro ⟨t, t₀⟩
-        simp [expSumSq]
-        apply mul_le_mul_of_nonneg_right _ (sq_nonneg _)
-        calc ‖∑ r, a r * e (ξ r * t)‖
-            ≤ ∑ r, ‖a r * e (ξ r * t)‖ := norm_sum_le _ _
-          _ = ∑ r, ‖a r‖ := by simp [norm_e]
-          _ ≤ _ := by
-              calc ∑ r, ‖a r‖
-                  ≤ Real.sqrt (Finset.card Finset.univ) *
-                    Real.sqrt (∑ r, ‖a r‖^2) := by
-                      apply (Finset.inner_mul_le_norm_sq_mul_norm_sq _ _).trans
-                      simp
-                _ = _ := by simp [hnorm, Real.sqrt_one]
-  -- Rearrange: ∫_I F = T - ∫_ℝ F·E
-  have hrearrange :
-      ∫ t in Set.Icc a₀ b₀, expSumSq a ξ t =
-      T - ∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t := by
-    simp only [kernelE]
-    -- ∫ F·(1/N ∫_I |ψ̂|² - 1_I) = 1/N ∫ F(∫_I |ψ̂|²) - ∫_I F
-    rw [integral_sub]
-    · rw [integral_const_mul, mul_comm N, hFubini]
-      rw [integral_indicator measurableSet_Icc]
-      simp; ring
-    · exact (integrable_const _).mul_right _
-    · exact (integrable_indicator measurableSet_Icc).mul_left _
-  exact hrearrange
+    rw [setIntegral_const, Real.volume_real_Icc_of_le hab, smul_eq_mul, hT]
+    ring
+  -- Fubini, with the interval restriction built into the first measure.
+  have hswap :
+      (∫ t₀ in Set.Icc a₀ b₀, ∫ t : ℝ, H (t₀, t)) =
+      ∫ t : ℝ, ∫ t₀ in Set.Icc a₀ b₀, H (t₀, t) := by
+    exact integral_integral_swap hH_int
+  have hFubini : ∫ t : ℝ, F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t) = N * T := by
+    calc
+      ∫ t : ℝ, F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t) =
+          ∫ t : ℝ, ∫ t₀ in Set.Icc a₀ b₀, H (t₀, t) := by
+            congr 1
+            ext t
+            change F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t) =
+              ∫ t₀ in Set.Icc a₀ b₀, F t * K t₀ t
+            rw [integral_const_mul]
+      _ = ∫ t₀ in Set.Icc a₀ b₀, ∫ t : ℝ, H (t₀, t) := hswap.symm
+      _ = ∫ _ in Set.Icc a₀ b₀, N := by
+        apply setIntegral_congr_fun measurableSet_Icc
+        intro t₀ _
+        exact h31 t₀
+      _ = N * T := hNT
+  have hFK_int : Integrable (fun t : ℝ => F t *
+      (∫ t₀ in Set.Icc a₀ b₀, K t₀ t)) := by
+    have hmarginal := hH_int.integral_prod_right
+    apply hmarginal.congr
+    apply ae_of_all
+    intro t
+    change (∫ t₀ in Set.Icc a₀ b₀, F t * K t₀ t) =
+      F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t)
+    rw [integral_const_mul]
+  have hFI_int : Integrable ((Set.Icc a₀ b₀).indicator F) :=
+    hF_cont.integrableOn_Icc.integrable_indicator measurableSet_Icc
+  have hexpand : (fun t : ℝ => expSumSq a ξ t * kernelE N a₀ b₀ t) =
+      fun t => (1 / N) * (F t * (∫ t₀ in Set.Icc a₀ b₀, K t₀ t)) -
+        (Set.Icc a₀ b₀).indicator F t := by
+    funext t
+    simp only [kernelE, F, K]
+    by_cases ht : t ∈ Set.Icc a₀ b₀
+    · rw [Set.indicator_of_mem ht, Set.indicator_of_mem ht]
+      ring
+    · rw [Set.indicator_of_notMem ht, Set.indicator_of_notMem ht]
+      ring
+  rw [hexpand, integral_sub (hFK_int.const_mul _) hFI_int,
+    integral_const_mul, hFubini, integral_indicator measurableSet_Icc]
+  field_simp
+  ring
 
 -- ============================================================
 -- GOAL 5: E(t) ≪ (1 + dist(t,∂I)/N)^{-10}

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -1,4 +1,9 @@
- import Mathlib
+import expdb.basic
+import Mathlib.Analysis.Fourier.FourierTransform
+import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+import Mathlib.Tactic
 
 open MeasureTheory Real Complex Filter Topology BigOperators
 
@@ -35,12 +40,12 @@ namespace BumpData
 -- ψ has compact support
 lemma hasCompactSupport (B : BumpData) : HasCompactSupport B.ψ :=
   HasCompactSupport.of_support_subset_isCompact
-    (isCompact_Icc (a := -1/4) (b := 1/4))
+    (isCompact_Icc (a := -1 / 4) (b := 1 / 4))
     (fun x hx => by
       simp only [Function.mem_support] at hx
       have h := B.supp x hx
       simp only [Set.mem_Icc, abs_le] at h ⊢
-      exact ⟨h.1, h.2⟩)
+      simpa only [neg_div] using h)
 
 -- ψ̂(u) = ∫_ℝ ψ(x) e(-xu) dx
 def psiHat (ψ : ℝ → ℝ) (u : ℝ) : ℂ :=

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -90,7 +90,7 @@ lemma psi_l2norm : ∫ x : ℝ, (ψ x) ^ 2 = 1 := by
 
 -- ψ̂(u) = ∫_ℝ ψ(x) e(-xu) dx
 def psiHat (u : ℝ) : ℂ :=
-  ∫ x : ℝ, (ψ x : ℂ) * (Real.fourierChar (-(x * u)) : ℂ)
+  ∫ x : ℝ, (ψ x : ℂ) * 𝐞 (-(x * u))
 
 -- ψ is integrable
 lemma psi_integrable : Integrable ψ :=
@@ -133,7 +133,7 @@ lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^
 
 /-- The exponential sum occurring in the $L^2$ integral estimate. -/
 def expSum {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℂ :=
-  ∑ r, a r * (Real.fourierChar (ξ r * t) : ℂ)
+  ∑ r, a r * 𝐞 (ξ r * t)
 
 /-- The squared modulus of `expSum`. -/
 def expSumSq {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℝ :=
@@ -288,13 +288,13 @@ private lemma psiShift_apply (w x : ℝ) : psiShift w x = ψ (x + w) := rfl
 
 private lemma fourier_psiShift (w u : ℝ) :
     (𝓕 (psiShift w : ℝ → ℂ)) u =
-      (Real.fourierChar (w * u) : ℂ) * psiHat u := by
+      𝐞 (w * u) * psiHat u := by
   have hcoe : (psiShift w : ℝ → ℂ) = fun x : ℝ => (ψ (x + w) : ℂ) := by
     ext x
     exact_mod_cast psiShift_apply w x
   rw [hcoe, Real.fourier_real_eq]
   have hpsi : psiHat u =
-      ∫ x : ℝ, (Real.fourierChar (-(x * u)) : ℂ) * (ψ x : ℂ) := by
+      ∫ x : ℝ, 𝐞 (-(x * u)) * (ψ x : ℂ) := by
     simp only [psiHat]
     apply integral_congr_ae
     filter_upwards with x
@@ -358,7 +358,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ) :
     ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-  let c : Fin R → ℂ := fun r => a r * (Real.fourierChar (ξ r * t₀) : ℂ)
+  let c : Fin R → ℂ := fun r => a r * 𝐞 (ξ r * t₀)
   let G : 𝓢(ℝ, ℂ) := ∑ r, c r • psiShift (N * ξ r)
   have hfourier (u : ℝ) :
       (𝓕 G : 𝓢(ℝ, ℂ)) u = expSum a ξ (t₀ + N * u) * psiHat u := by
@@ -376,13 +376,13 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     simp_rw [SchwartzMap.smul_apply, smul_eq_mul]
     have hshift (r : Fin R) :
         SchwartzMap.fourierTransformCLM ℂ (psiShift (N * ξ r)) u =
-          (Real.fourierChar ((N * ξ r) * u) : ℂ) * psiHat u := by
+          𝐞 ((N * ξ r) * u) * psiHat u := by
       rw [SchwartzMap.fourierTransformCLM_apply]
       rw [SchwartzMap.fourier_coe]
       exact fourier_psiShift (N * ξ r) u
     simp_rw [hshift]
-    rw [show (∑ r, c r * ((Real.fourierChar ((N * ξ r) * u) : ℂ) * psiHat u)) =
-        (∑ r, c r * (Real.fourierChar ((N * ξ r) * u) : ℂ)) * psiHat u by
+    rw [show (∑ r, c r * (𝐞 ((N * ξ r) * u) * psiHat u)) =
+        (∑ r, c r * 𝐞 ((N * ξ r) * u)) * psiHat u by
       rw [Finset.sum_mul]
       apply Finset.sum_congr rfl
       intro r _
@@ -392,11 +392,9 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     intro r _
     simp only [c]
     calc
-      a r * (Real.fourierChar (ξ r * t₀) : ℂ) *
-          (Real.fourierChar ((N * ξ r) * u) : ℂ) =
-          a r * ((Real.fourierChar (ξ r * t₀) : ℂ) *
-            (Real.fourierChar ((N * ξ r) * u) : ℂ)) := by ring
-      _ = a r * (Real.fourierChar (ξ r * (t₀ + N * u)) : ℂ) := by
+      a r * 𝐞 (ξ r * t₀) * 𝐞 ((N * ξ r) * u) =
+          a r * (𝐞 (ξ r * t₀) * 𝐞 ((N * ξ r) * u)) := by ring
+      _ = a r * 𝐞 (ξ r * (t₀ + N * u)) := by
         simp only [Real.fourierChar_apply]
         rw [← Complex.exp_add]
         congr 2
@@ -1136,7 +1134,7 @@ theorem l2_integral_estimate :
     left ≤ right →
     ∃ θ : ℝ, |θ| ≤ C ∧
     ∫ t in Set.Icc left right,
-      ‖∑ r, a r * (Real.fourierChar (ξ r * t) : ℂ)‖ ^ 2 =
+      ‖∑ r, a r * 𝐞 (ξ r * t)‖ ^ 2 =
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2 := by
   obtain ⟨C, hC, herror⟩ := goal6
   refine ⟨C, hC, ?_⟩

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -2,6 +2,7 @@ import expdb.basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.BumpFunction.InnerProduct
 import Mathlib.Analysis.Distribution.FourierSchwartz
+import Mathlib.Analysis.InnerProductSpace.Orthonormal
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.Tactic
@@ -252,14 +253,13 @@ lemma psiHat_lower_bound :
 -- ============================================================
 -- GOAL 2: ∫_ℝ F(t) |ψ̂((t-t₀)/N)|² dt = N   [equation (3.1)]
 --
--- From handwritten proof:
---   Step 1 (r=s): ∑|aᵣ|² · N ∫|ψ̂(u)|² du = N  (Plancherel)
---   Step 2 (r≠s): = 0  (support analysis: |q|≥1/N but support
---                        forces |q|≤1/(2N), contradiction)
+-- Apply Plancherel once to the sum of translates
+--   G(x) = ∑ᵣ aᵣe(ξᵣt₀)ψ(x + Nξᵣ).
+-- Its Fourier transform is the weighted exponential sum after t=t₀+Nu,
+-- while the translates of ψ form an orthonormal family by separation.
 -- ============================================================
 
--- Package translates of the concrete bump as Schwartz functions so that the
--- off-diagonal Fourier integrals can be evaluated by Plancherel.
+-- Package translates of the concrete bump as Schwartz functions.
 private def psiShift (w : ℝ) : 𝓢(ℝ, ℂ) := by
   let f : ℝ → ℂ := fun x => (ψ (x + w) : ℂ)
   have hcomp : HasCompactSupport f := by
@@ -293,255 +293,163 @@ private lemma fourier_psiShift (w u : ℝ) :
     (Fourier.fourierIntegral_comp_add_right 𝐞 volume (fun x : ℝ => (ψ x : ℂ)) w) u
   simpa [Fourier.fourierIntegral_def, Circle.smul_def, e, Real.fourierChar_apply] using ht
 
-private lemma psiShift_inner_eq_zero {w : ℝ} (hw : 1 ≤ |w|) :
-    ∫ x : ℝ, inner ℂ (psiSchwartz x) (psiShift w x) = 0 := by
+private lemma psiShift_inner_eq_zero {v w : ℝ} (hvw : 1 ≤ |v - w|) :
+    ∫ x : ℝ, inner ℂ (psiShift v x) (psiShift w x) = 0 := by
   apply integral_eq_zero_of_ae
   filter_upwards with x
-  by_cases hx : ψ x = 0
-  · simp [psiSchwartz, hx]
+  by_cases hxv : ψ (x + v) = 0
+  · simp [psiShift_apply, hxv]
   by_cases hxw : ψ (x + w) = 0
   · simp [psiShift_apply, hxw]
   exfalso
-  have h1 := psi_supp x hx
-  have h2 := psi_supp (x + w) hxw
-  have hbound : |w| ≤ 1 / 2 := by
+  have hv := psi_supp (x + v) hxv
+  have hw := psi_supp (x + w) hxw
+  have hbound : |v - w| ≤ 1 / 2 := by
     calc
-      |w| = |(x + w) - x| := by ring_nf
-      _ = |(x + w) + (-x)| := by ring
-      _ ≤ |x + w| + |-x| := abs_add_le _ _
-      _ = |x + w| + |x| := by rw [abs_neg]
+      |v - w| = |(x + v) - (x + w)| := by ring_nf
+      _ ≤ |x + v| + |x + w| := abs_sub _ _
       _ ≤ 1 / 4 + 1 / 4 := by linarith
       _ = 1 / 2 := by norm_num
   linarith
 
-private lemma psiHat_orthogonal {w : ℝ} (hw : 1 ≤ |w|) :
-    ∫ u : ℝ, e (w * u) * ‖psiHat u‖ ^ 2 = 0 := by
-  have hpl := SchwartzMap.integral_inner_fourier_fourier psiSchwartz (psiShift w)
-  rw [psiShift_inner_eq_zero hw] at hpl
-  have hshift : ((𝓕 (psiShift w) : 𝓢(ℝ, ℂ)) : ℝ → ℂ) =
-      fun u => e (w * u) * psiHat u := by
-    rw [SchwartzMap.fourier_coe]
-    ext u
-    exact fourier_psiShift w u
-  have hbase : ((𝓕 psiSchwartz : 𝓢(ℝ, ℂ)) : ℝ → ℂ) = psiHat := by
-    rw [SchwartzMap.fourier_coe]
-    exact psiHat_eq_fourier.symm
-  have hleft : (fun u : ℝ => inner ℂ (𝓕 psiSchwartz u) (𝓕 (psiShift w) u)) =
-      fun u => e (w * u) * ‖psiHat u‖ ^ 2 := by
-    funext u
-    rw [RCLike.inner_apply, hshift, hbase]
-    change (e (w * u) * psiHat u) * (starRingEnd ℂ) (psiHat u) = _
-    rw [mul_assoc, Complex.mul_conj']
-  rw [hleft] at hpl
-  exact hpl
+private lemma psiShift_inner_self (w : ℝ) :
+    ∫ x : ℝ, inner ℂ (psiShift w x) (psiShift w x) = 1 := by
+  calc
+    ∫ x : ℝ, inner ℂ (psiShift w x) (psiShift w x) =
+        ∫ x : ℝ, (((ψ (x + w)) ^ 2 : ℝ) : ℂ) := by
+          apply integral_congr_ae
+          filter_upwards with x
+          simp [psiShift_apply, abs_of_nonneg (psi_nonneg _)]
+    _ = ((∫ x : ℝ, (ψ (x + w)) ^ 2 : ℝ) : ℂ) := integral_ofReal
+    _ = ((∫ x : ℝ, (ψ x) ^ 2 : ℝ) : ℂ) := by
+      rw [integral_add_right_eq_self (fun x : ℝ => (ψ x) ^ 2) w]
+    _ = 1 := by rw [psi_l2norm]; norm_num
 
-private lemma scaled_psiHat_orthogonal {q N t₀ : ℝ} (hN : 0 < N)
-    (hq : 1 / N ≤ |q|) :
-    ∫ t : ℝ, e (q * t) * (((‖psiHat ((t - t₀) / N)‖ ^ 2 : ℝ) : ℂ)) = 0 := by
-  have hqN : 1 ≤ |q * N| := by
-    rw [abs_mul, abs_of_pos hN]
+private lemma psiShift_orthonormal {R : ℕ} (ξ : Fin R → ℝ) (N : ℝ) (hN : 0 < N)
+    (hsep : IsSeparatedFamily (1 / N) ξ) :
+    Orthonormal ℂ (fun r => (psiShift (N * ξ r)).toLp 2) := by
+  rw [orthonormal_iff_ite]
+  intro r s
+  rw [SchwartzMap.inner_toL2_toL2_eq
+    (psiShift (N * ξ r)) (psiShift (N * ξ s)) volume]
+  by_cases hrs : r = s
+  · subst s
+    rw [if_pos rfl, psiShift_inner_self]
+  · rw [if_neg hrs]
+    apply psiShift_inner_eq_zero
+    rw [show N * ξ r - N * ξ s = N * (ξ r - ξ s) by ring, abs_mul, abs_of_pos hN]
     calc
-      1 = (1 / N) * N := by field_simp
-      _ ≤ |q| * N := mul_le_mul_of_nonneg_right hq hN.le
-  let F : ℝ → ℂ := fun u => e (q * (N * u + t₀)) * (((‖psiHat u‖ ^ 2 : ℝ) : ℂ))
-  have hrewrite : (fun t : ℝ =>
-      e (q * t) * (((‖psiHat ((t - t₀) / N)‖ ^ 2 : ℝ) : ℂ))) =
-      fun t => F ((1 / N) * t + (-t₀ / N)) := by
-    funext t
-    simp only [F]
-    rw [show (1 / N) * t + -t₀ / N = (t - t₀) / N by
-      field_simp
-      ring]
-    congr 2
-    field_simp
-    ring
-  rw [hrewrite]
-  let H : ℝ → ℂ := fun x => F (x + (-t₀ / N))
-  change ∫ t : ℝ, H ((1 / N) * t) = 0
-  rw [Measure.integral_comp_mul_left H (1 / N)]
-  rw [show (∫ y : ℝ, H y) = ∫ y : ℝ, F y by
-    exact integral_add_right_eq_self F (-t₀ / N)]
-  have hF : (fun u : ℝ => F u) =
-      fun u => e (q * t₀) *
-        (e ((q * N) * u) * (((‖psiHat u‖ ^ 2 : ℝ) : ℂ))) := by
-    funext u
-    simp only [F]
-    rw [show q * (N * u + t₀) = q * t₀ + (q * N) * u by ring, e_add]
-    ring
-  have hFint : ∫ u : ℝ, F u = 0 := by
-    rw [hF, integral_const_mul]
-    rw [show (∫ u : ℝ,
-        e ((q * N) * u) * (((‖psiHat u‖ ^ 2 : ℝ) : ℂ))) = 0 by
-      simpa only [Complex.ofReal_pow] using psiHat_orthogonal hqN]
-    simp
-  rw [hFint]
-  simp
-
-private lemma star_e (x : ℝ) : starRingEnd ℂ (e x) = e (-x) := by
-  unfold e
-  rw [← Complex.exp_conj]
-  simp only [map_mul, map_ofNat, Complex.conj_ofReal, Complex.conj_I]
-  congr 1
-  push_cast
-  ring
-
--- Scaling and integrability facts used to exchange the finite sums and integral
--- in `goal2`.
-private lemma scaled_psiHat_l2 (N t₀ : ℝ) (hN : 0 < N) :
-    ∫ t : ℝ, ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-  let F : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
-  let H : ℝ → ℝ := fun x => F (x + (-t₀ / N))
-  have hrewrite : (fun t : ℝ => ‖psiHat ((t - t₀) / N)‖ ^ 2) =
-      fun t => H ((1 / N) * t) := by
-    funext t
-    simp only [H, F]
-    congr 2
-    field_simp
-    ring_nf
-  rw [hrewrite, Measure.integral_comp_mul_left H (1 / N)]
-  rw [show (∫ y : ℝ, H y) = ∫ y : ℝ, F y by
-    exact integral_add_right_eq_self F (-t₀ / N)]
-  rw [show (∫ y : ℝ, F y) = 1 by exact psiHat_l2]
-  simp [abs_of_pos hN]
-
-private lemma psiHat_sq_integrable : Integrable (fun u : ℝ => ‖psiHat u‖ ^ 2) := by
-  by_contra h
-  have hz := integral_undef h
-  rw [psiHat_l2] at hz
-  norm_num at hz
-
-private lemma scaled_psiHat_sq_integrable (N t₀ : ℝ) (hN : 0 < N) :
-    Integrable (fun t : ℝ => ‖psiHat ((t - t₀) / N)‖ ^ 2) := by
-  have h := (psiHat_sq_integrable.comp_add_right (-t₀ / N)).comp_mul_left'
-    (show 1 / N ≠ 0 by positivity)
-  convert h using 1
-  ext t
-  congr 2
-  field_simp
-  ring_nf
-
-private lemma scaled_phase_integrable (q N t₀ : ℝ) (hN : 0 < N) :
-    Integrable (fun t : ℝ =>
-      e (q * t) * (((‖psiHat ((t - t₀) / N)‖ ^ 2 : ℝ) : ℂ))) := by
-  refine (scaled_psiHat_sq_integrable N t₀ hN).ofReal.bdd_mul
-    (f := fun t => e (q * t)) (c := 1) ?_ ?_
-  · apply Continuous.aestronglyMeasurable
-    unfold e
-    fun_prop
-  · filter_upwards with t
-    rw [norm_e]
+      1 = N * (1 / N) := by field_simp
+      _ ≤ N * |ξ r - ξ s| := mul_le_mul_of_nonneg_left (hsep r s hrs) hN.le
 
 theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (t₀ : ℝ)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ) :
     ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-  let W : ℝ → ℝ := fun t => ‖psiHat ((t - t₀) / N)‖ ^ 2
-  let B : Fin R → Fin R → ℝ → ℂ := fun r s t =>
-    a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t) * (W t : ℂ)
-  have hexpand : ∀ t : ℝ,
-      expSumSq a ξ t =
-      (∑ r : Fin R, ∑ s : Fin R,
-        a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t)).re := by
-    intro t
-    simp only [expSumSq, expSum]
-    rw [show ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
-        ((∑ r, a r * e (ξ r * t)) * starRingEnd ℂ (∑ r, a r * e (ξ r * t))).re by
-          rw [Complex.sq_norm, Complex.mul_conj]
-          exact (Complex.ofReal_re _).symm]
-    apply congrArg Complex.re
-    rw [map_sum, Finset.sum_mul]
-    simp_rw [Finset.mul_sum]
+  let c : Fin R → ℂ := fun r => a r * e (ξ r * t₀)
+  let G : 𝓢(ℝ, ℂ) := ∑ r, c r • psiShift (N * ξ r)
+  have hfourier (u : ℝ) :
+      (𝓕 G : 𝓢(ℝ, ℂ)) u = expSum a ξ (t₀ + N * u) * psiHat u := by
+    change (SchwartzMap.fourierTransformCLM ℂ
+      (∑ r, c r • psiShift (N * ξ r))) u = _
+    rw [map_sum]
+    simp_rw [map_smul]
+    have hsum_apply (s : Finset (Fin R)) (f : Fin R → 𝓢(ℝ, ℂ)) :
+        (∑ r ∈ s, f r) u = ∑ r ∈ s, f r u := by
+      induction s using Finset.induction_on with
+      | empty => simp
+      | @insert r s hrs ih =>
+          simp [Finset.sum_insert, hrs, SchwartzMap.add_apply, ih]
+    rw [hsum_apply Finset.univ]
+    simp_rw [SchwartzMap.smul_apply, smul_eq_mul]
+    have hshift (r : Fin R) :
+        SchwartzMap.fourierTransformCLM ℂ (psiShift (N * ξ r)) u =
+          e ((N * ξ r) * u) * psiHat u := by
+      rw [SchwartzMap.fourierTransformCLM_apply]
+      rw [SchwartzMap.fourier_coe]
+      exact fourier_psiShift (N * ξ r) u
+    simp_rw [hshift]
+    rw [show (∑ r, c r * (e ((N * ξ r) * u) * psiHat u)) =
+        (∑ r, c r * e ((N * ξ r) * u)) * psiHat u by
+      rw [Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro r _
+      ring]
+    congr 1
     apply Finset.sum_congr rfl
     intro r _
-    apply Finset.sum_congr rfl
-    intro s _
-    rw [map_mul, star_e]
+    simp only [c]
     calc
-      a r * e (ξ r * t) * ((starRingEnd ℂ) (a s) * e (-(ξ s * t))) =
-          a r * (starRingEnd ℂ) (a s) * (e (ξ r * t) * e (-(ξ s * t))) := by ring
-      _ = a r * (starRingEnd ℂ) (a s) * e ((ξ r - ξ s) * t) := by
+      a r * e (ξ r * t₀) * e ((N * ξ r) * u) =
+          a r * (e (ξ r * t₀) * e ((N * ξ r) * u)) := by ring
+      _ = a r * e (ξ r * (t₀ + N * u)) := by
         rw [← e_add]
-        congr 1
-        ring_nf
-  have hBint (r s : Fin R) : Integrable (B r s) := by
-    convert (scaled_phase_integrable (ξ r - ξ s) N t₀ hN).const_mul
-      (a r * starRingEnd ℂ (a s)) using 1
-    simp [B, W, mul_assoc]
-  have hsumInt : Integrable (fun t : ℝ => ∑ r : Fin R, ∑ s : Fin R, B r s t) := by
-    apply integrable_finset_sum
-    intro r _
-    apply integrable_finset_sum
-    intro s _
-    exact hBint r s
-  have hpair (r s : Fin R) :
-      ∫ t : ℝ, B r s t =
-        if r = s then (N : ℂ) * ((‖a r‖ ^ 2 : ℝ) : ℂ) else 0 := by
-    have hfactor :
-        (∫ t : ℝ, B r s t) =
-          (a r * starRingEnd ℂ (a s)) *
-            ∫ t : ℝ, e ((ξ r - ξ s) * t) * (W t : ℂ) := by
-      rw [show B r s = fun t : ℝ =>
-          (a r * starRingEnd ℂ (a s)) *
-            (e ((ξ r - ξ s) * t) * (W t : ℂ)) by
-        funext t
-        simp only [B]
-        ring]
-      rw [integral_const_mul]
-    by_cases hrs : r = s
-    · subst s
-      rw [if_pos rfl]
-      rw [hfactor]
-      simp only [sub_self, zero_mul, e_zero, one_mul]
-      rw [show (∫ t : ℝ, (W t : ℂ)) = (N : ℂ) by
-        calc
-          (∫ t : ℝ, (W t : ℂ)) = (((∫ t : ℝ, W t) : ℝ) : ℂ) := integral_ofReal
-          _ = (N : ℂ) := congrArg (fun x : ℝ => (x : ℂ))
-            (by simpa only [W] using scaled_psiHat_l2 N t₀ hN)]
-      rw [Complex.mul_conj']
-      rw [← Complex.ofReal_pow]
+        congr 2
+        ring
+  have hG_toLp :
+      G.toLp 2 = ∑ r, c r • (psiShift (N * ξ r)).toLp 2 := by
+    change SchwartzMap.toLpCLM ℂ ℂ 2 volume G = _
+    simp [G]
+  have hG_norm : ‖G.toLp 2‖ ^ 2 = 1 := by
+    have horth := (psiShift_orthonormal ξ N hN hsep).inner_sum c c Finset.univ
+    have hc_norm : ∑ r, ‖c r‖ ^ 2 = 1 := by
+      simpa only [c, norm_mul, norm_e, mul_one] using hnorm
+    have hsum_norm :
+        ‖∑ r, c r • (psiShift (N * ξ r)).toLp 2‖ ^ 2 = ∑ r, ‖c r‖ ^ 2 := by
+      calc
+        ‖∑ r, c r • (psiShift (N * ξ r)).toLp 2‖ ^ 2 =
+            (inner ℂ (∑ r, c r • (psiShift (N * ξ r)).toLp 2)
+              (∑ r, c r • (psiShift (N * ξ r)).toLp 2)).re :=
+                by
+                  exact norm_sq_eq_re_inner (𝕜 := ℂ)
+                    (∑ r, c r • (psiShift (N * ξ r)).toLp 2)
+        _ = (∑ r, (starRingEnd ℂ) (c r) * c r).re := congrArg Complex.re horth
+        _ = ∑ r, ‖c r‖ ^ 2 := by
+          rw [Complex.re_sum]
+          apply Finset.sum_congr rfl
+          intro r _
+          rw [Complex.conj_mul']
+          rw [← Complex.ofReal_pow, Complex.ofReal_re]
+    rw [hG_toLp, hsum_norm, hc_norm]
+  have hG_inner : inner ℂ (G.toLp 2) (G.toLp 2) = 1 := by
+    rw [inner_self_eq_norm_sq_to_K]
+    simpa only [Complex.ofReal_pow, Complex.ofReal_one] using
+      congrArg (fun x : ℝ => (x : ℂ)) hG_norm
+  have hG_l2 : ∫ x : ℝ, ‖G x‖ ^ 2 = 1 := by
+    have hinner_integral : ∫ x : ℝ, inner ℂ (G x) (G x) = 1 := by
+      rw [← SchwartzMap.inner_toL2_toL2_eq G G volume]
+      exact hG_inner
+    apply Complex.ofRealLI.injective
+    simpa [← LinearIsometry.integral_comp_comm, inner_self_eq_norm_sq_to_K] using hinner_integral
+  let H : ℝ → ℝ := fun u => ‖(𝓕 G : 𝓢(ℝ, ℂ)) u‖ ^ 2
+  have hrewrite : (fun t : ℝ =>
+      expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2) =
+      fun t => H ((1 / N) * t + (-t₀ / N)) := by
+    funext t
+    rw [show (1 / N) * t + -t₀ / N = (t - t₀) / N by
+      field_simp
+      ring]
+    have hu : t₀ + N * ((t - t₀) / N) = t := by
+      field_simp
       ring
-    · rw [if_neg hrs]
-      rw [hfactor]
-      rw [show (∫ t : ℝ, e ((ξ r - ξ s) * t) * (W t : ℂ)) = 0 by
-        simpa only [W] using scaled_psiHat_orthogonal hN (hsep r s hrs)]
-      simp
-  have hcomplex : (∫ t : ℝ, ∑ r : Fin R, ∑ s : Fin R, B r s t) = (N : ℂ) := by
-    rw [integral_finset_sum Finset.univ (fun r _ => by
-      apply integrable_finset_sum
-      intro s _
-      exact hBint r s)]
-    simp_rw [integral_finset_sum Finset.univ (fun s _ => hBint _ s), hpair]
-    simp only [Finset.sum_ite_eq, Finset.mem_univ, if_true]
-    rw [← Finset.mul_sum, show
-      (∑ r : Fin R, (((‖a r‖ ^ 2 : ℝ) : ℂ))) = 1 by exact_mod_cast hnorm, mul_one]
-  calc
-    ∫ t : ℝ, expSumSq a ξ t * W t =
-        ∫ t : ℝ, (∑ r : Fin R, ∑ s : Fin R, B r s t).re := by
-          apply integral_congr_ae
-          filter_upwards with t
-          rw [hexpand]
-          have hBsum :
-              (∑ r : Fin R, ∑ s : Fin R, B r s t) =
-                (∑ r : Fin R, ∑ s : Fin R,
-                  a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t)) * (W t : ℂ) := by
-            simp only [B]
-            symm
-            rw [Finset.sum_mul]
-            apply Finset.sum_congr rfl
-            intro r _
-            rw [Finset.sum_mul]
-          rw [hBsum]
-          simp only [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, mul_zero, sub_zero]
-    _ = (∫ t : ℝ, ∑ r : Fin R, ∑ s : Fin R, B r s t).re :=
-      integral_re hsumInt
-    _ = N := by simpa using congrArg Complex.re hcomplex
+    simp only [H, hfourier, hu, expSumSq, norm_mul, mul_pow]
+  rw [hrewrite]
+  let K : ℝ → ℝ := fun x => H (x + (-t₀ / N))
+  change ∫ t : ℝ, K ((1 / N) * t) = N
+  rw [Measure.integral_comp_mul_left K (1 / N)]
+  rw [show (∫ y : ℝ, K y) = ∫ y : ℝ, H y by
+    exact integral_add_right_eq_self H (-t₀ / N)]
+  rw [show (∫ y : ℝ, H y) = 1 by
+    simpa only [H] using (SchwartzMap.integral_norm_sq_fourier G).trans hG_l2]
+  simp [abs_of_pos hN]
 
 -- ============================================================
 -- GOAL 3: ∫_J |∑ aᵣ e(ξᵣ t)|² dt ≪ N for |J| = N  [eq (3.2)]
 --
---   Step 2: |ψ̂((t-t₀)/N)|² ≥ c·1_{[-δ/2,δ/2]}((t-t₀)/N)
---   Step 3: N ≥ c · ∫_{J_{t₀}} F dt → ∫_J F ≪ N/c ≪ N
+-- Enlarge the smoothing scale from N to M ≍ψ N so that the whole normalized
+-- interval lies in the neighbourhood where |ψ̂|² has a positive lower bound.
+-- Goal 2 at scale M then gives c·∫_J F ≤ M ≪ψ N.
 -- ============================================================
 
 theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
@@ -551,42 +459,72 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (a₀ : ℝ) :
     ∃ C : ℝ, 0 < C ∧
     ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
-  -- Get lower bound c for |ψ̂|² near 0
   obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound
-  -- Choose t₀ = center of J
+  -- Enlarge the smoothing scale so that the whole interval lies in the
+  -- neighbourhood on which `psiHat_lower_bound` applies.
+  set M := N * (1 + 1 / δ)
+  have hM : 0 < M := by
+    dsimp [M]
+    positivity
+  have hNM : N ≤ M := by
+    have hinvδ : 0 ≤ 1 / δ := by positivity
+    dsimp [M]
+    nlinarith
+  have hsepM : IsSeparatedFamily (1 / M) ξ := by
+    intro r s hrs
+    apply le_trans _ (hsep r s hrs)
+    apply (div_le_div_iff₀ hM hN).2
+    simpa using hNM
   set t₀ := a₀ + N / 2
-  -- From Goal 2: N = ∫_ℝ F|ψ̂((t-t₀)/N)|² dt
-  have h2 := goal2 a ξ N hN t₀ hnorm hsep
-  -- On J = [a₀, a₀+N]: |(t-t₀)/N| ≤ 1/2
-  -- If δ ≥ 1/2, then |ψ̂((t-t₀)/N)|² ≥ c on J
+  have h2 := goal2 a ξ M hM t₀ hnorm hsepM
   have hlb_J : ∀ t ∈ Set.Icc a₀ (a₀ + N),
-      c ≤ ‖psiHat ((t - t₀) / N)‖ ^ 2 := by
+      c ≤ ‖psiHat ((t - t₀) / M)‖ ^ 2 := by
     intro t ht
     apply hlb
-    simp only [t₀, abs_le, div_le_iff hN, neg_mul, le_div_iff hN]
-    constructor <;> [linarith [ht.1]; linarith [ht.2]]
-  -- Therefore: N ≥ c · ∫_J F → ∫_J F ≤ N/c
-  refine ⟨1 / c, by positivity, ?_⟩
-  have hFub : c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ N := by
+    rw [abs_div, abs_of_pos hM]
+    apply (div_le_iff₀ hM).2
+    have habs : |t - t₀| ≤ N / 2 := by
+      rw [abs_le]
+      constructor <;> simp only [t₀] <;> linarith [ht.1, ht.2]
+    apply habs.trans
+    have hscale : δ * M = δ * N + N := by
+      dsimp [M]
+      field_simp
+    rw [hscale]
+    nlinarith
+  have hFcont : Continuous (expSumSq a ξ) := by
+    unfold expSumSq expSum e
+    fun_prop
+  have hweighted : Integrable (fun t : ℝ =>
+      expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2) := by
+    by_contra h
+    rw [integral_undef h] at h2
+    linarith
+  refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
+  have hFub : c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ M := by
     calc c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t
         = ∫ t in Set.Icc a₀ (a₀ + N), c * expSumSq a ξ t :=
             (integral_const_mul _ _).symm
       _ ≤ ∫ t in Set.Icc a₀ (a₀ + N),
-            expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 := by
-          apply set_integral_mono_ae
-          · exact (measurable_const.mul (by measurability)).aestronglyMeasurable
-          · exact (by measurability).aestronglyMeasurable
-          · apply ae_restrict_of_ae; apply ae_of_all; intro t
-            by_cases ht : t ∈ Set.Icc a₀ (a₀ + N)
-            · exact mul_le_mul_of_nonneg_left (hlb_J t ht)
-                (by simp [expSumSq]; positivity)
-            · simp
-      _ ≤ ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 :=
-          set_integral_le_integral _
-            (fun t => mul_nonneg (by simp [expSumSq]; positivity) (sq_nonneg _))
-      _ = N := h2
-  rw [div_mul_eq_mul_div, le_div_iff hc]
-  exact hFub
+            expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2 := by
+          apply setIntegral_mono_on
+          · exact (continuous_const.mul hFcont).integrableOn_Icc
+          · exact hweighted.integrableOn
+          · exact measurableSet_Icc
+          · intro t ht
+            calc
+              c * expSumSq a ξ t = expSumSq a ξ t * c := by ring
+              _ ≤ expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2 :=
+                mul_le_mul_of_nonneg_left (hlb_J t ht) (sq_nonneg _)
+      _ ≤ ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2 :=
+          setIntegral_le_integral hweighted (ae_of_all _ fun t =>
+            mul_nonneg (sq_nonneg _) (sq_nonneg _))
+      _ = M := h2
+  rw [show (1 + 1 / δ) / c * N = M / c by
+    dsimp [M]
+    ring]
+  apply (le_div_iff₀ hc).2
+  nlinarith
 
 -- ============================================================
 -- GOAL 4: ∫_I F = T - ∫_ℝ F·E  (Fubini identity)

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -120,7 +120,8 @@ lemma psi_integral_pos : 0 < ∫ x : ℝ, ψ x := by
 -- "Let M = ∑|aᵣ|², let Aᵣ = aᵣ/M^{1/2} → ∑|Aᵣ|² = 1"
 -- ============================================================
 
-lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^ 2)
+lemma goal1 {ι : Type*} [Fintype ι] (a : ι → ℂ) (M : ℝ)
+    (hM : M = ∑ r, ‖a r‖ ^ 2)
     (hpos : 0 < M) :
     ∑ r, ‖(fun r => a r / (Real.sqrt M : ℂ)) r‖ ^ 2 = 1 := by
   simp_rw [norm_div]
@@ -138,6 +139,17 @@ def expSum {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ
 /-- The squared modulus of `expSum`. -/
 def expSumSq {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℝ :=
   ‖expSum a ξ t‖ ^ 2
+
+private lemma expSumSq_nonneg {ι : Type*} [Fintype ι]
+    (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) :
+    0 ≤ expSumSq a ξ t :=
+  sq_nonneg _
+
+private lemma expSumSq_continuous {ι : Type*} [Fintype ι]
+    (a : ι → ℂ) (ξ : ι → ℝ) :
+    Continuous (expSumSq a ξ) := by
+  unfold expSumSq expSum
+  fun_prop
 
 -- ============================================================
 -- Plancherel: ‖ψ̂‖_{L²} = ‖ψ‖_{L²} = 1
@@ -168,6 +180,10 @@ private lemma psiHat_eq_fourier : psiHat = 𝓕 (psiSchwartz : ℝ → ℂ) := b
   apply integral_congr_ae
   filter_upwards with x
   ring
+
+private lemma psiHat_continuous : Continuous psiHat := by
+  rw [psiHat_eq_fourier]
+  exact (𝓕 psiSchwartz).continuous
 
 lemma psiHat_l2 : ∫ u : ℝ, ‖psiHat u‖ ^ 2 = 1 := by
   simp_rw [psiHat_eq_fourier]
@@ -224,9 +240,7 @@ lemma psiHat_decay (K : ℕ) :
 lemma psiHat_lower_bound :
     ∃ c δ : ℝ, 0 < c ∧ 0 < δ ∧
     ∀ u : ℝ, |u| ≤ δ → c ≤ ‖psiHat u‖ ^ 2 := by
-  have hcts : Continuous psiHat := by
-    rw [psiHat_eq_fourier]
-    exact (𝓕 psiSchwartz).continuous
+  have hcts : Continuous psiHat := psiHat_continuous
   have hpsi0_eq : (psiHat 0).re = ∫ x : ℝ, ψ x := by
     simp only [psiHat, mul_zero, neg_zero]
     have hψc : Integrable (fun x : ℝ => (ψ x : ℂ)) := psi_integrable.ofReal
@@ -336,9 +350,11 @@ private lemma psiShift_inner_self (w : ℝ) :
       rw [integral_add_right_eq_self (fun x : ℝ => (ψ x) ^ 2) w]
     _ = 1 := by rw [psi_l2norm]; norm_num
 
-private lemma psiShift_orthonormal {R : ℕ} (ξ : Fin R → ℝ) (N : ℝ) (hN : 0 < N)
+private lemma psiShift_orthonormal {ι : Type*} [Fintype ι]
+    (ξ : ι → ℝ) (N : ℝ) (hN : 0 < N)
     (hsep : IsSeparatedFamily (1 / N) ξ) :
     Orthonormal ℂ (fun r => (psiShift (N * ξ r)).toLp 2) := by
+  classical
   rw [orthonormal_iff_ite]
   intro r s
   rw [SchwartzMap.inner_toL2_toL2_eq
@@ -351,14 +367,15 @@ private lemma psiShift_orthonormal {R : ℕ} (ξ : Fin R → ℝ) (N : ℝ) (hN 
     rw [show N * ξ r - N * ξ s = N * (ξ r - ξ s) by ring, abs_mul, abs_of_pos hN]
     calc
       1 = N * (1 / N) := by field_simp
-      _ ≤ N * |ξ r - ξ s| := mul_le_mul_of_nonneg_left (hsep r s hrs) hN.le
+      _ ≤ N * |ξ r - ξ s| := mul_le_mul_of_nonneg_left (hsep hrs) hN.le
 
-theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal2 {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ)
     (N : ℝ) (hN : 0 < N) (t₀ : ℝ)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ) :
     ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-  let c : Fin R → ℂ := fun r => a r * 𝐞 (ξ r * t₀)
+  classical
+  let c : ι → ℂ := fun r => a r * 𝐞 (ξ r * t₀)
   let G : 𝓢(ℝ, ℂ) := ∑ r, c r • psiShift (N * ξ r)
   have hfourier (u : ℝ) :
       (𝓕 G : 𝓢(ℝ, ℂ)) u = expSum a ξ (t₀ + N * u) * psiHat u := by
@@ -366,7 +383,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
       (∑ r, c r • psiShift (N * ξ r))) u = _
     rw [map_sum]
     simp_rw [map_smul]
-    have hsum_apply (s : Finset (Fin R)) (f : Fin R → 𝓢(ℝ, ℂ)) :
+    have hsum_apply (s : Finset ι) (f : ι → 𝓢(ℝ, ℂ)) :
         (∑ r ∈ s, f r) u = ∑ r ∈ s, f r u := by
       induction s using Finset.induction_on with
       | empty => simp
@@ -374,7 +391,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
           simp [Finset.sum_insert, hrs, SchwartzMap.add_apply, ih]
     rw [hsum_apply Finset.univ]
     simp_rw [SchwartzMap.smul_apply, smul_eq_mul]
-    have hshift (r : Fin R) :
+    have hshift (r : ι) :
         SchwartzMap.fourierTransformCLM ℂ (psiShift (N * ξ r)) u =
           𝐞 ((N * ξ r) * u) * psiHat u := by
       rw [SchwartzMap.fourierTransformCLM_apply]
@@ -467,7 +484,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 
 theorem goal3 :
     ∃ C : ℝ, 0 < C ∧
-    ∀ {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ) (N : ℝ),
+    ∀ {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (N : ℝ),
     0 < N →
     (∑ r, ‖a r‖ ^ 2 = 1) →
     IsSeparatedFamily (1 / N) ξ →
@@ -475,7 +492,7 @@ theorem goal3 :
     ∫ t in Set.Icc j₀ (j₀ + N), expSumSq a ξ t ≤ C * N := by
   obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound
   refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
-  intro R a ξ N hN hnorm hsep j₀
+  intro ι _ a ξ N hN hnorm hsep j₀
   -- Enlarge the smoothing scale so that the whole interval lies in the
   -- neighbourhood on which `psiHat_lower_bound` applies.
   set M := N * (1 + 1 / δ)
@@ -488,7 +505,7 @@ theorem goal3 :
     nlinarith
   have hsepM : IsSeparatedFamily (1 / M) ξ := by
     intro r s hrs
-    apply le_trans _ (hsep r s hrs)
+    apply le_trans _ (hsep hrs)
     apply (div_le_div_iff₀ hM hN).2
     simpa using hNM
   set t₀ := j₀ + N / 2
@@ -508,9 +525,7 @@ theorem goal3 :
       field_simp
     rw [hscale]
     nlinarith
-  have hFcont : Continuous (expSumSq a ξ) := by
-    unfold expSumSq expSum
-    fun_prop
+  have hFcont : Continuous (expSumSq a ξ) := expSumSq_continuous a ξ
   have hweighted : Integrable (fun t : ℝ =>
       expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2) := by
     by_contra h
@@ -571,7 +586,7 @@ private lemma kernelAverage_eq_intervalIntegral (N : ℝ) (hN : 0 < N)
       (f := fun u : ℝ => ‖psiHat u‖ ^ 2) (a := left) (b := right) N (t / N)).trans (by
         congr 1 <;> field_simp)
 
-theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem goal4 {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ)
@@ -581,17 +596,12 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   let F : ℝ → ℝ := expSumSq a ξ
   let K : ℝ → ℝ → ℝ := fun t₀ t => ‖psiHat ((t - t₀) / N)‖ ^ 2
   let H : ℝ × ℝ → ℝ := fun p => F p.2 * K p.1 p.2
-  have hF_nonneg : ∀ t, 0 ≤ F t := fun t => sq_nonneg _
+  have hF_nonneg : ∀ t, 0 ≤ F t := expSumSq_nonneg a ξ
   have hK_nonneg : ∀ t₀ t, 0 ≤ K t₀ t := fun t₀ t => sq_nonneg _
   have hH_nonneg : ∀ p, 0 ≤ H p := fun p =>
     mul_nonneg (hF_nonneg p.2) (hK_nonneg p.1 p.2)
-  have hF_cont : Continuous F := by
-    dsimp [F]
-    unfold expSumSq expSum
-    fun_prop
-  have hpsiHat_cont : Continuous psiHat := by
-    rw [psiHat_eq_fourier]
-    exact (𝓕 psiSchwartz).continuous
+  have hF_cont : Continuous F := expSumSq_continuous a ξ
+  have hpsiHat_cont : Continuous psiHat := psiHat_continuous
   have hK_cont : Continuous (fun p : ℝ × ℝ => K p.1 p.2) := by
     exact ((hpsiHat_cont.comp
       ((continuous_snd.sub continuous_fst).div_const N)).norm.pow 2)
@@ -876,7 +886,7 @@ private lemma kernelE_aestronglyMeasurable (N : ℝ) (hN : 0 < N)
 
 theorem goal6 :
     ∃ C : ℝ, 0 < C ∧
-    ∀ {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ) (N : ℝ),
+    ∀ {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (N : ℝ),
     0 < N →
     (∑ r, ‖a r‖ ^ 2 = 1) →
     IsSeparatedFamily (1 / N) ξ →
@@ -897,13 +907,10 @@ theorem goal6 :
   let B := ∑' k : ℤ, b k
   have hB : 0 ≤ B := tsum_nonneg hb_nonneg
   refine ⟨2 * C₅ * C₃ * (B + 1), by positivity, ?_⟩
-  intro R a ξ N hN hnorm hsep left right hleft_right
+  intro ι _ a ξ N hN hnorm hsep left right hleft_right
   let F : ℝ → ℝ := expSumSq a ξ
-  have hF_nonneg : ∀ t, 0 ≤ F t := fun t => sq_nonneg _
-  have hF_cont : Continuous F := by
-    dsimp [F]
-    unfold expSumSq expSum
-    fun_prop
+  have hF_nonneg : ∀ t, 0 ≤ F t := expSumSq_nonneg a ξ
+  have hF_cont : Continuous F := expSumSq_continuous a ξ
   have hlocal := hlocal_bound a ξ N hN hnorm hsep
   have hE := hkernel_bound N hN left right hleft_right
   let weight : ℝ → ℝ → ℝ :=
@@ -1126,7 +1133,7 @@ theorem goal6 :
 -- ============================================================
 theorem l2_integral_estimate :
     ∃ C : ℝ, 0 < C ∧
-    ∀ {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ) (N : ℝ),
+    ∀ {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (N : ℝ),
     0 < N →
     IsSeparatedFamily (1 / N) ξ →
     ∀ left right T : ℝ,
@@ -1138,7 +1145,7 @@ theorem l2_integral_estimate :
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2 := by
   obtain ⟨C, hC, herror⟩ := goal6
   refine ⟨C, hC, ?_⟩
-  intro R a ξ N hN hsep left right T hT hleft_right
+  intro ι _ a ξ N hN hsep left right T hT hleft_right
   change ∃ θ : ℝ, |θ| ≤ C ∧
     ∫ t in Set.Icc left right, expSumSq a ξ t =
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2
@@ -1160,7 +1167,7 @@ theorem l2_integral_estimate :
   ·
     have hMpos : 0 < M :=
       lt_of_le_of_ne (Finset.sum_nonneg fun r _ => sq_nonneg _) (Ne.symm hM0)
-    set A : Fin R → ℂ := fun r => a r / (Real.sqrt M : ℂ)
+    set A : ι → ℂ := fun r => a r / (Real.sqrt M : ℂ)
     have hAnorm : ∑ r, ‖A r‖ ^ 2 = 1 := goal1 a M rfl hMpos
     have hsqrt_ne : (Real.sqrt M : ℂ) ≠ 0 :=
       Complex.ofReal_ne_zero.mpr (Real.sqrt_ne_zero'.mpr hMpos)
@@ -1203,5 +1210,31 @@ theorem l2_integral_estimate :
         _ = (T + (-err / N) * N) * M := by
           rw [div_mul_cancel₀ (-err) hN.ne']
           ring
+
+/-- Absolute-error form of the $L^2$ integral estimate. -/
+theorem l2_integral_estimate_error :
+    ∃ C : ℝ, 0 < C ∧
+    ∀ {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (N : ℝ),
+    0 < N →
+    IsSeparatedFamily (1 / N) ξ →
+    ∀ left right T : ℝ,
+    T = right - left →
+    left ≤ right →
+    |(∫ t in Set.Icc left right, ‖∑ r, a r * 𝐞 (ξ r * t)‖ ^ 2) -
+        T * ∑ r, ‖a r‖ ^ 2| ≤
+      C * N * ∑ r, ‖a r‖ ^ 2 := by
+  obtain ⟨C, hC, hestimate⟩ := l2_integral_estimate
+  refine ⟨C, hC, ?_⟩
+  intro ι _ a ξ N hN hsep left right T hT hleft_right
+  obtain ⟨θ, hθ, hidentity⟩ :=
+    hestimate a ξ N hN hsep left right T hT hleft_right
+  let S := ∑ r, ‖a r‖ ^ 2
+  have hS : 0 ≤ S := Finset.sum_nonneg fun r _ => sq_nonneg ‖a r‖
+  rw [hidentity]
+  calc
+    |(T + θ * N) * S - T * S| = |θ| * N * S := by
+      rw [show (T + θ * N) * S - T * S = θ * N * S by ring,
+        abs_mul, abs_mul, abs_of_pos hN, abs_of_nonneg hS]
+    _ ≤ C * N * S := by gcongr
 
 end

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -128,6 +128,14 @@ lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^
   rw [← hM, Real.sq_sqrt hpos.le]
   exact div_self (ne_of_gt hpos)
 
+/-- The exponential sum occurring in the $L^2$ integral estimate. -/
+def expSum {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℂ :=
+  ∑ r, a r * e (ξ r * t)
+
+/-- The squared modulus of `expSum`. -/
+def expSumSq {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℝ :=
+  ‖expSum a ξ t‖ ^ 2
+
 -- ============================================================
 -- Plancherel: ‖ψ̂‖_{L²} = ‖ψ‖_{L²} = 1
 -- From proof: "∑|aᵣ|² ∫|ψ̂((t-t₀)/N)|² dt, let u=(t-t₀)/N
@@ -250,106 +258,284 @@ lemma psiHat_lower_bound :
 --                        forces |q|≤1/(2N), contradiction)
 -- ============================================================
 
+-- Package translates of the concrete bump as Schwartz functions so that the
+-- off-diagonal Fourier integrals can be evaluated by Plancherel.
+private def psiShift (w : ℝ) : 𝓢(ℝ, ℂ) := by
+  let f : ℝ → ℂ := fun x => (ψ (x + w) : ℂ)
+  have hcomp : HasCompactSupport f := by
+    apply HasCompactSupport.of_support_subset_isCompact
+      (isCompact_Icc (a := -w - 1 / 4) (b := -w + 1 / 4))
+    intro x hx
+    change (ψ (x + w) : ℂ) ≠ 0 at hx
+    have hx' : ψ (x + w) ≠ 0 := by exact_mod_cast hx
+    have h := abs_le.mp (psi_supp (x + w) hx')
+    constructor <;> linarith
+  have hsmooth : ContDiff ℝ ∞ f := by
+    simpa only [f, Function.comp_apply] using
+      psi_complex_smooth.comp (contDiff_id.add contDiff_const)
+  exact hcomp.toSchwartzMap hsmooth
+
+private lemma psiShift_apply (w x : ℝ) : psiShift w x = ψ (x + w) := rfl
+
+private lemma fourier_psiShift (w u : ℝ) :
+    (𝓕 (psiShift w : ℝ → ℂ)) u = e (w * u) * psiHat u := by
+  have hcoe : (psiShift w : ℝ → ℂ) = fun x : ℝ => (ψ (x + w) : ℂ) := by
+    ext x
+    exact_mod_cast psiShift_apply w x
+  rw [hcoe, Real.fourier_real_eq]
+  have hpsi : psiHat u = ∫ x : ℝ, e (-(x * u)) * (ψ x : ℂ) := by
+    simp only [psiHat]
+    apply integral_congr_ae
+    filter_upwards with x
+    ring
+  rw [hpsi]
+  have ht := congr_fun
+    (Fourier.fourierIntegral_comp_add_right 𝐞 volume (fun x : ℝ => (ψ x : ℂ)) w) u
+  simpa [Fourier.fourierIntegral_def, Circle.smul_def, e, Real.fourierChar_apply] using ht
+
+private lemma psiShift_inner_eq_zero {w : ℝ} (hw : 1 ≤ |w|) :
+    ∫ x : ℝ, inner ℂ (psiSchwartz x) (psiShift w x) = 0 := by
+  apply integral_eq_zero_of_ae
+  filter_upwards with x
+  by_cases hx : ψ x = 0
+  · simp [psiSchwartz, hx]
+  by_cases hxw : ψ (x + w) = 0
+  · simp [psiShift_apply, hxw]
+  exfalso
+  have h1 := psi_supp x hx
+  have h2 := psi_supp (x + w) hxw
+  have hbound : |w| ≤ 1 / 2 := by
+    calc
+      |w| = |(x + w) - x| := by ring_nf
+      _ = |(x + w) + (-x)| := by ring
+      _ ≤ |x + w| + |-x| := abs_add_le _ _
+      _ = |x + w| + |x| := by rw [abs_neg]
+      _ ≤ 1 / 4 + 1 / 4 := by linarith
+      _ = 1 / 2 := by norm_num
+  linarith
+
+private lemma psiHat_orthogonal {w : ℝ} (hw : 1 ≤ |w|) :
+    ∫ u : ℝ, e (w * u) * ‖psiHat u‖ ^ 2 = 0 := by
+  have hpl := SchwartzMap.integral_inner_fourier_fourier psiSchwartz (psiShift w)
+  rw [psiShift_inner_eq_zero hw] at hpl
+  have hshift : ((𝓕 (psiShift w) : 𝓢(ℝ, ℂ)) : ℝ → ℂ) =
+      fun u => e (w * u) * psiHat u := by
+    rw [SchwartzMap.fourier_coe]
+    ext u
+    exact fourier_psiShift w u
+  have hbase : ((𝓕 psiSchwartz : 𝓢(ℝ, ℂ)) : ℝ → ℂ) = psiHat := by
+    rw [SchwartzMap.fourier_coe]
+    exact psiHat_eq_fourier.symm
+  have hleft : (fun u : ℝ => inner ℂ (𝓕 psiSchwartz u) (𝓕 (psiShift w) u)) =
+      fun u => e (w * u) * ‖psiHat u‖ ^ 2 := by
+    funext u
+    rw [RCLike.inner_apply, hshift, hbase]
+    change (e (w * u) * psiHat u) * (starRingEnd ℂ) (psiHat u) = _
+    rw [mul_assoc, Complex.mul_conj']
+  rw [hleft] at hpl
+  exact hpl
+
+private lemma scaled_psiHat_orthogonal {q N t₀ : ℝ} (hN : 0 < N)
+    (hq : 1 / N ≤ |q|) :
+    ∫ t : ℝ, e (q * t) * (((‖psiHat ((t - t₀) / N)‖ ^ 2 : ℝ) : ℂ)) = 0 := by
+  have hqN : 1 ≤ |q * N| := by
+    rw [abs_mul, abs_of_pos hN]
+    calc
+      1 = (1 / N) * N := by field_simp
+      _ ≤ |q| * N := mul_le_mul_of_nonneg_right hq hN.le
+  let F : ℝ → ℂ := fun u => e (q * (N * u + t₀)) * (((‖psiHat u‖ ^ 2 : ℝ) : ℂ))
+  have hrewrite : (fun t : ℝ =>
+      e (q * t) * (((‖psiHat ((t - t₀) / N)‖ ^ 2 : ℝ) : ℂ))) =
+      fun t => F ((1 / N) * t + (-t₀ / N)) := by
+    funext t
+    simp only [F]
+    rw [show (1 / N) * t + -t₀ / N = (t - t₀) / N by
+      field_simp
+      ring]
+    congr 2
+    field_simp
+    ring
+  rw [hrewrite]
+  let H : ℝ → ℂ := fun x => F (x + (-t₀ / N))
+  change ∫ t : ℝ, H ((1 / N) * t) = 0
+  rw [Measure.integral_comp_mul_left H (1 / N)]
+  rw [show (∫ y : ℝ, H y) = ∫ y : ℝ, F y by
+    exact integral_add_right_eq_self F (-t₀ / N)]
+  have hF : (fun u : ℝ => F u) =
+      fun u => e (q * t₀) *
+        (e ((q * N) * u) * (((‖psiHat u‖ ^ 2 : ℝ) : ℂ))) := by
+    funext u
+    simp only [F]
+    rw [show q * (N * u + t₀) = q * t₀ + (q * N) * u by ring, e_add]
+    ring
+  have hFint : ∫ u : ℝ, F u = 0 := by
+    rw [hF, integral_const_mul]
+    rw [show (∫ u : ℝ,
+        e ((q * N) * u) * (((‖psiHat u‖ ^ 2 : ℝ) : ℂ))) = 0 by
+      simpa only [Complex.ofReal_pow] using psiHat_orthogonal hqN]
+    simp
+  rw [hFint]
+  simp
+
+private lemma star_e (x : ℝ) : starRingEnd ℂ (e x) = e (-x) := by
+  unfold e
+  rw [← Complex.exp_conj]
+  simp only [map_mul, map_ofNat, Complex.conj_ofReal, Complex.conj_I]
+  congr 1
+  push_cast
+  ring
+
+-- Scaling and integrability facts used to exchange the finite sums and integral
+-- in `goal2`.
+private lemma scaled_psiHat_l2 (N t₀ : ℝ) (hN : 0 < N) :
+    ∫ t : ℝ, ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
+  let F : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
+  let H : ℝ → ℝ := fun x => F (x + (-t₀ / N))
+  have hrewrite : (fun t : ℝ => ‖psiHat ((t - t₀) / N)‖ ^ 2) =
+      fun t => H ((1 / N) * t) := by
+    funext t
+    simp only [H, F]
+    congr 2
+    field_simp
+    ring
+  rw [hrewrite, Measure.integral_comp_mul_left H (1 / N)]
+  rw [show (∫ y : ℝ, H y) = ∫ y : ℝ, F y by
+    exact integral_add_right_eq_self F (-t₀ / N)]
+  rw [show (∫ y : ℝ, F y) = 1 by exact psiHat_l2]
+  simp [abs_of_pos hN]
+
+private lemma psiHat_sq_integrable : Integrable (fun u : ℝ => ‖psiHat u‖ ^ 2) := by
+  by_contra h
+  have hz := integral_undef h
+  rw [psiHat_l2] at hz
+  norm_num at hz
+
+private lemma scaled_psiHat_sq_integrable (N t₀ : ℝ) (hN : 0 < N) :
+    Integrable (fun t : ℝ => ‖psiHat ((t - t₀) / N)‖ ^ 2) := by
+  have h := (psiHat_sq_integrable.comp_add_right (-t₀ / N)).comp_mul_left'
+    (show 1 / N ≠ 0 by positivity)
+  convert h using 1
+  ext t
+  congr 2
+  field_simp
+  ring
+
+private lemma scaled_phase_integrable (q N t₀ : ℝ) (hN : 0 < N) :
+    Integrable (fun t : ℝ =>
+      e (q * t) * (((‖psiHat ((t - t₀) / N)‖ ^ 2 : ℝ) : ℂ))) := by
+  refine (scaled_psiHat_sq_integrable N t₀ hN).ofReal.bdd_mul
+    (f := fun t => e (q * t)) (c := 1) ?_ ?_
+  · apply Continuous.aestronglyMeasurable
+    unfold e
+    fun_prop
+  · filter_upwards with t
+    rw [norm_e]
+
 theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (t₀ : ℝ)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : Separated N ξ) :
+    (hsep : IsSeparatedFamily (1 / N) ξ) :
     ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-  simp only [expSumSq]
-  -- Expand |∑ aᵣ e(ξᵣt)|² = ∑ᵣ ∑ₛ aᵣ·ā_s·e((ξᵣ-ξₛ)t)
+  let W : ℝ → ℝ := fun t => ‖psiHat ((t - t₀) / N)‖ ^ 2
+  let B : Fin R → Fin R → ℝ → ℂ := fun r s t =>
+    a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t) * (W t : ℂ)
   have hexpand : ∀ t : ℝ,
-      ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
+      expSumSq a ξ t =
       (∑ r : Fin R, ∑ s : Fin R,
         a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t)).re := by
     intro t
-    rw [← Complex.normSq_eq_sq]
-    simp [Complex.normSq_apply, Finset.sum_mul, Finset.mul_sum,
-          ← Complex.exp_add, e_def]
-    congr 1; ext r; congr 1; ext s
-    congr 1; push_cast; ring
-  -- Substitute the expansion
-  simp_rw [hexpand]
-  -- Split diagonal (r=s) and off-diagonal (r≠s)
-  have hdiag_offdiag : ∀ t : ℝ,
-      (∑ r : Fin R, ∑ s : Fin R,
-        a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t)).re =
-      ∑ r : Fin R, ‖a r‖ ^ 2 +
-      (∑ r : Fin R, ∑ s ∈ (Finset.univ (α := Fin R)).filter (· ≠ r),
-        a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t)).re := by
-    intro t
-    simp [Finset.sum_add_sum_compl, Complex.add_re]
-    congr 1
-    · simp [map_mul, Complex.normSq_eq_conj_mul_self, Complex.normSq_apply]
-    · apply Finset.sum_congr rfl; intro r _
-      rw [← Finset.sum_filter]
-  simp_rw [hdiag_offdiag]
-  rw [integral_add]
-  -- STEP 1 (r=s): = ∑|aᵣ|² · N = N
-  · simp_rw [integral_add]
-    · -- ∑|aᵣ|² · ∫|ψ̂((t-t₀)/N)|² dt = N
-      conv_lhs =>
-        arg 1
-        ext t
-        rw [show ∑ r : Fin R, ‖a r‖ ^ 2 = (1 : ℝ) from hnorm]
-      rw [one_mul]
-      -- Substitute u = (t-t₀)/N: ∫|ψ̂((t-t₀)/N)|² dt = N·∫|ψ̂(u)|² du = N
-      have : ∫ t : ℝ, ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-        rw [show (fun t => ‖psiHat ((t - t₀) / N)‖ ^ 2) =
-            fun t => ‖psiHat ((1/N) * t + (-t₀/N))‖ ^ 2 from by
-          ext t; congr 2; field_simp; ring]
-        rw [integral_comp_mul_add _ (1/N) (-t₀/N) (by simp [hN.ne'])]
-        simp [abs_of_pos (by positivity : (0:ℝ) < 1/N)]
-        rw [psiHat_l2, mul_one]
-      exact this
-    · exact integrable_const
-    · exact (Continuous.integrable_of_hasCompactSupport (by continuity)
-        (HasCompactSupport.of_support_subset_isCompact (isCompact_Icc)
-          (fun t _ => Set.mem_Icc.mpr ⟨by norm_num, by norm_num⟩)))
-  -- STEP 2 (r≠s): = 0  [support analysis]
-  · -- For each r ≠ s, show ∫ aᵣā_s e((ξᵣ-ξₛ)t)|ψ̂((t-t₀)/N)|² dt = 0
-    -- by showing the convolution ∫ ψ(v)ψ(v-qN)dv = 0 when |q|≥1/N
-    rw [integral_re]
-    apply integral_eq_zero_of_forall_eq_zero
-    · intro t
-      simp only [Finset.sum_re, Complex.re_sum, Finset.sum_eq_zero_iff]
-      intro r _
-      apply Finset.sum_eq_zero
-      intro s hs
-      simp only [Finset.mem_filter] at hs
-      set q := ξ r - ξ s
-      have hq : |q| ≥ 1 / N := hsep r s hs.2
-      -- Key: ∫ ψ(v)ψ(v-qN) dv = 0 when |qN| > 1/2
-      have hconv : ∫ v : ℝ, ψ v * ψ (v - q * N) = 0 := by
-        apply integral_eq_zero_of_forall_eq_zero
-        intro v
-        by_cases h1 : ψ v = 0
-        · simp [h1]
-        · by_cases h2 : ψ (v - q * N) = 0
-          · simp [h2]
-          · exfalso
-            -- |v| ≤ 1/4 and |v - qN| ≤ 1/4 → |qN| ≤ 1/2
-            have hv := psi_supp v h1
-            have hvq := psi_supp (v - q * N) h2
-            have hcontra : |q * N| ≤ 1/2 := by
-              calc |q * N| = |v - (v - q * N)| := by ring_nf
-                _ ≤ |v| + |v - q * N| := abs_sub_abs_le_abs_sub _ _
-                _ ≤ 1/4 + 1/4 := by linarith
-                _ = 1/2 := by norm_num
-            -- But |q| ≥ 1/N → |qN| ≥ 1
-            have hbig : |q * N| ≥ 1 := by
-              rw [abs_mul, abs_of_pos hN]
-              have := mul_le_mul_of_nonneg_right hq (abs_nonneg N)
-              simp [abs_of_pos hN] at this ⊢; linarith
-            linarith
-      -- Connect hconv to the original integral via Fourier analysis
-      simp [hconv]
-    · exact (integrable_const 1).mono (ae_of_all _ (fun t => by simp [expSumSq]; positivity))
-  · exact integrable_const
-  · apply integrable_finset_sum; intro r _
-    apply integrable_finset_sum; intro s _
-    apply Integrable.re
-    apply Integrable.const_mul
-    exact (integrable_const 1).mono (ae_of_all _ (fun t => by simp [norm_e]; positivity))
+    simp only [expSumSq, expSum]
+    rw [show ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
+        ((∑ r, a r * e (ξ r * t)) * starRingEnd ℂ (∑ r, a r * e (ξ r * t))).re by
+          rw [Complex.sq_norm, Complex.mul_conj]
+          exact (Complex.ofReal_re _).symm]
+    apply congrArg Complex.re
+    rw [map_sum, Finset.sum_mul]
+    simp_rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro r _
+    apply Finset.sum_congr rfl
+    intro s _
+    rw [map_mul, star_e]
+    calc
+      a r * e (ξ r * t) * ((starRingEnd ℂ) (a s) * e (-(ξ s * t))) =
+          a r * (starRingEnd ℂ) (a s) * (e (ξ r * t) * e (-(ξ s * t))) := by ring
+      _ = a r * (starRingEnd ℂ) (a s) * e ((ξ r - ξ s) * t) := by
+        rw [← e_add]
+        congr 1
+        ring
+  have hBint (r s : Fin R) : Integrable (B r s) := by
+    convert (scaled_phase_integrable (ξ r - ξ s) N t₀ hN).const_mul
+      (a r * starRingEnd ℂ (a s)) using 1
+    simp [B, W, mul_assoc]
+  have hsumInt : Integrable (fun t : ℝ => ∑ r : Fin R, ∑ s : Fin R, B r s t) := by
+    apply integrable_finset_sum
+    intro r _
+    apply integrable_finset_sum
+    intro s _
+    exact hBint r s
+  have hpair (r s : Fin R) :
+      ∫ t : ℝ, B r s t =
+        if r = s then (N : ℂ) * ((‖a r‖ ^ 2 : ℝ) : ℂ) else 0 := by
+    have hfactor :
+        (∫ t : ℝ, B r s t) =
+          (a r * starRingEnd ℂ (a s)) *
+            ∫ t : ℝ, e ((ξ r - ξ s) * t) * (W t : ℂ) := by
+      rw [show B r s = fun t : ℝ =>
+          (a r * starRingEnd ℂ (a s)) *
+            (e ((ξ r - ξ s) * t) * (W t : ℂ)) by
+        funext t
+        simp only [B]
+        ring]
+      rw [integral_const_mul]
+    by_cases hrs : r = s
+    · subst s
+      rw [if_pos rfl]
+      rw [hfactor]
+      simp only [sub_self, zero_mul, e_zero, one_mul]
+      rw [show (∫ t : ℝ, (W t : ℂ)) = (N : ℂ) by
+        calc
+          (∫ t : ℝ, (W t : ℂ)) = (((∫ t : ℝ, W t) : ℝ) : ℂ) := integral_ofReal
+          _ = (N : ℂ) := congrArg (fun x : ℝ => (x : ℂ))
+            (by simpa only [W] using scaled_psiHat_l2 N t₀ hN)]
+      rw [Complex.mul_conj']
+      rw [← Complex.ofReal_pow]
+      ring
+    · rw [if_neg hrs]
+      rw [hfactor]
+      rw [show (∫ t : ℝ, e ((ξ r - ξ s) * t) * (W t : ℂ)) = 0 by
+        simpa only [W] using scaled_psiHat_orthogonal hN (hsep r s hrs)]
+      simp
+  have hcomplex : (∫ t : ℝ, ∑ r : Fin R, ∑ s : Fin R, B r s t) = (N : ℂ) := by
+    rw [integral_finset_sum Finset.univ (fun r _ => by
+      apply integrable_finset_sum
+      intro s _
+      exact hBint r s)]
+    simp_rw [integral_finset_sum Finset.univ (fun s _ => hBint _ s), hpair]
+    simp only [Finset.sum_ite_eq, Finset.mem_univ, if_true]
+    rw [← Finset.mul_sum, show
+      (∑ r : Fin R, (((‖a r‖ ^ 2 : ℝ) : ℂ))) = 1 by exact_mod_cast hnorm, mul_one]
+  calc
+    ∫ t : ℝ, expSumSq a ξ t * W t =
+        ∫ t : ℝ, (∑ r : Fin R, ∑ s : Fin R, B r s t).re := by
+          apply integral_congr_ae
+          filter_upwards with t
+          rw [hexpand]
+          have hBsum :
+              (∑ r : Fin R, ∑ s : Fin R, B r s t) =
+                (∑ r : Fin R, ∑ s : Fin R,
+                  a r * starRingEnd ℂ (a s) * e ((ξ r - ξ s) * t)) * (W t : ℂ) := by
+            simp only [B]
+            symm
+            rw [Finset.sum_mul]
+            apply Finset.sum_congr rfl
+            intro r _
+            rw [Finset.sum_mul]
+          rw [hBsum]
+          simp only [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, mul_zero, sub_zero]
+    _ = (∫ t : ℝ, ∑ r : Fin R, ∑ s : Fin R, B r s t).re :=
+      integral_re hsumInt
+    _ = N := by simpa using congrArg Complex.re hcomplex
 
 -- ============================================================
 -- GOAL 3: ∫_J |∑ aᵣ e(ξᵣ t)|² dt ≪ N for |J| = N  [eq (3.2)]
@@ -361,7 +547,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : Separated N ξ)
+    (hsep : IsSeparatedFamily (1 / N) ξ)
     (a₀ : ℝ) :
     ∃ C : ℝ, 0 < C ∧
     ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
@@ -420,7 +606,7 @@ def kernelE (N : ℝ) (a₀ b₀ : ℝ) (t : ℝ) : ℝ :=
 theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : Separated N ξ)
+    (hsep : IsSeparatedFamily (1 / N) ξ)
     (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
     ∫ t in Set.Icc a₀ b₀, expSumSq a ξ t =
     T - ∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t := by
@@ -651,7 +837,7 @@ have hint : Integrable (fun u => ‖psiHat u‖ ^ 2) := by
 theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : Separated N ξ)
+    (hsep : IsSeparatedFamily (1 / N) ξ)
     (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
     ∃ C : ℝ, 0 < C ∧
     |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t| ≤ C * N := by
@@ -762,7 +948,7 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- ============================================================
 
 theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
-    (N : ℝ) (hN : 0 < N) (hsep : Separated N ξ)
+    (N : ℝ) (hN : 0 < N) (hsep : IsSeparatedFamily (1 / N) ξ)
     (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :
     ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
     ∫ t in Set.Icc a₀ b₀, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -1112,68 +1112,75 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --         = T + O(N)·1   (by Goal 6: |∫ F·E| ≪ N)
 --              = (T + O(N)) · ∑|aᵣ|²  (by Goal 1: WLOG)
 -- ============================================================
-theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+theorem l2_integral_estimate {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (hsep : IsSeparatedFamily (1 / N) ξ)
     (left right : ℝ) (T : ℝ) (hT : T = right - left) (hleft_right : left ≤ right) :
     ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
     ∫ t in Set.Icc left right, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2 := by
+  change ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
+    ∫ t in Set.Icc left right, expSumSq a ξ t =
+    (T + θ * N) * ∑ r, ‖a r‖ ^ 2
   set M := ∑ r, ‖a r‖ ^ 2
-  -- Trivial case: M = 0 → all aᵣ = 0
   by_cases hM0 : M = 0
   · refine ⟨1, one_pos, 0, by simp, ?_⟩
+    have hsum_zero : ∑ r, ‖a r‖ ^ 2 = 0 := by
+      simpa only [M] using hM0
+    have hterm_zero : ∀ r, ‖a r‖ ^ 2 = 0 := by
+      intro r
+      exact ((Finset.sum_eq_zero_iff_of_nonneg
+        (s := Finset.univ) (f := fun i => ‖a i‖ ^ 2)
+        (fun i _ => sq_nonneg _)).1 hsum_zero) r (Finset.mem_univ r)
     have hzero : ∀ r, a r = 0 := by
       intro r
-      have h1 : 0 ≤ ‖a r‖ ^ 2 := sq_nonneg _
-      have h2 : ‖a r‖ ^ 2 ≤ M :=
-        Finset.single_le_sum (fun i _ => sq_nonneg _) _ (Finset.mem_univ r)
-      have h3 : ‖a r‖ = 0 := by
-        nlinarith [hM0 ▸ h2]
-      exact norm_eq_zero.mp h3
-    simp [hM0, hzero]
-  · -- M > 0: normalize Aᵣ = aᵣ/√M
+      apply norm_eq_zero.mp
+      nlinarith [hterm_zero r, norm_nonneg (a r)]
+    simp [expSumSq, expSum, hzero, hM0]
+  ·
     have hMpos : 0 < M :=
       lt_of_le_of_ne (Finset.sum_nonneg fun r _ => sq_nonneg _) (Ne.symm hM0)
-    -- GOAL 1: define A with ∑|Aᵣ|² = 1
     set A : Fin R → ℂ := fun r => a r / (Real.sqrt M : ℂ)
     have hAnorm : ∑ r, ‖A r‖ ^ 2 = 1 := goal1 a M rfl hMpos
-    -- Rescaling: ‖expSum a‖² = M · ‖expSum A‖²
-    have hrescale : ∀ t,
-        ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
-        M * ‖∑ r, A r * e (ξ r * t)‖ ^ 2 := by
+    have hsqrt_ne : (Real.sqrt M : ℂ) ≠ 0 :=
+      Complex.ofReal_ne_zero.mpr (Real.sqrt_ne_zero'.mpr hMpos)
+    have hsqrt_mul_A : ∀ r, (Real.sqrt M : ℂ) * A r = a r := by
+      intro r
+      dsimp [A]
+      rw [mul_comm]
+      exact div_mul_cancel₀ _ hsqrt_ne
+    have hsum_scale : ∀ t,
+        expSum a ξ t = (Real.sqrt M : ℂ) * expSum A ξ t := by
       intro t
-      have : ∑ r, a r * e (ξ r * t) =
-          (Real.sqrt M : ℂ) * ∑ r, A r * e (ξ r * t) := by
-        simp [A, Finset.mul_sum, div_mul_cancel₀]
-        intro r
-        field_simp
-        rw [div_mul_cancel₀]
-        exact Complex.ofReal_ne_zero.mpr (Real.sqrt_ne_zero'.mpr hMpos)
-      rw [this, norm_mul, Complex.norm_ofReal,
-          abs_of_nonneg (Real.sqrt_nonneg M), mul_pow, Real.sq_sqrt hMpos.le]
-    -- Apply Goal 4 to get the Fubini identity
+      simp only [expSum]
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro r _
+      rw [← mul_assoc, hsqrt_mul_A r]
+    have hrescale : ∀ t, expSumSq a ξ t = M * expSumSq A ξ t := by
+      intro t
+      simp only [expSumSq]
+      rw [hsum_scale t, norm_mul, Complex.norm_real,
+        Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg M), mul_pow,
+        Real.sq_sqrt hMpos.le]
     have h4 := goal4 A ξ N hN hAnorm hsep left right T hT hleft_right
-    -- Apply Goal 6 to bound the error
     obtain ⟨C, hC, h6⟩ := goal6 A ξ N hN hAnorm hsep left right hleft_right
-    -- ∫_I ‖expSum A‖² = T - err,  |err| ≤ C·N
     set err := ∫ t : ℝ, expSumSq A ξ t * kernelE N left right t
     have hA_eq : ∫ t in Set.Icc left right, expSumSq A ξ t = T - err := by
-      simp [expSumSq] at h4 ⊢; exact h4
+      simpa only [err] using h4
     have herr_bd : |err| ≤ C * N := by
-      simp [expSumSq] at h6; exact h6
-    -- ∫_I ‖expSum a‖² = M · (T - err) = (T + θN) · M with θ = -err/N
+      simpa only [err] using h6
     refine ⟨C, hC, -err / N, ?_, ?_⟩
-    · -- |θ| = |err|/N ≤ C·N/N = C
-      rw [abs_div, abs_neg, abs_of_pos hN]
-      exact div_le_of_le_mul₀ hN.le (by positivity) (by linarith)
-    · -- ∫_I ‖expSum a‖² = (T + θN) · M
-      have ha_int : ∫ t in Set.Icc left right, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
-          M * (T - err) := by
-        conv_lhs => ext t; rw [hrescale t]
-        rw [integral_const_mul]
-        simp [expSumSq] at hA_eq
-        rw [hA_eq]
-      rw [ha_int]
-      field_simp; ring
+    · rw [abs_div, abs_neg, abs_of_pos hN, div_le_iff₀ hN]
+      exact herr_bd
+    · calc
+        ∫ t in Set.Icc left right, expSumSq a ξ t =
+            ∫ t in Set.Icc left right, M * expSumSq A ξ t :=
+          setIntegral_congr_fun measurableSet_Icc (fun t _ => hrescale t)
+        _ = M * ∫ t in Set.Icc left right, expSumSq A ξ t :=
+          integral_const_mul _ _
+        _ = M * (T - err) := by rw [hA_eq]
+        _ = (T + (-err / N) * N) * M := by
+          rw [div_mul_cancel₀ (-err) hN.ne']
+          ring
 
 end

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -90,7 +90,7 @@ lemma psi_l2norm : ∫ x : ℝ, (ψ x) ^ 2 = 1 := by
 
 -- ψ̂(u) = ∫_ℝ ψ(x) e(-xu) dx
 def psiHat (u : ℝ) : ℂ :=
-  ∫ x : ℝ, (ψ x : ℂ) * e (-(x * u))
+  ∫ x : ℝ, (ψ x : ℂ) * (Real.fourierChar (-(x * u)) : ℂ)
 
 -- ψ is integrable
 lemma psi_integrable : Integrable ψ :=
@@ -133,7 +133,7 @@ lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^
 
 /-- The exponential sum occurring in the $L^2$ integral estimate. -/
 def expSum {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℂ :=
-  ∑ r, a r * e (ξ r * t)
+  ∑ r, a r * (Real.fourierChar (ξ r * t) : ℂ)
 
 /-- The squared modulus of `expSum`. -/
 def expSumSq {ι : Type*} [Fintype ι] (a : ι → ℂ) (ξ : ι → ℝ) (t : ℝ) : ℝ :=
@@ -164,7 +164,7 @@ private def psiSchwartz : 𝓢(ℝ, ℂ) :=
 private lemma psiHat_eq_fourier : psiHat = 𝓕 (psiSchwartz : ℝ → ℂ) := by
   funext u
   rw [Real.fourier_real_eq]
-  simp [psiSchwartz, psiHat, e, Circle.smul_def, Real.fourierChar_apply]
+  simp [psiSchwartz, psiHat, Circle.smul_def, Real.fourierChar_apply]
   apply integral_congr_ae
   filter_upwards with x
   ring
@@ -228,7 +228,7 @@ lemma psiHat_lower_bound :
     rw [psiHat_eq_fourier]
     exact (𝓕 psiSchwartz).continuous
   have hpsi0_eq : (psiHat 0).re = ∫ x : ℝ, ψ x := by
-    simp only [psiHat, mul_zero, neg_zero, e_zero, mul_one]
+    simp only [psiHat, mul_zero, neg_zero]
     have hψc : Integrable (fun x : ℝ => (ψ x : ℂ)) := psi_integrable.ofReal
     simpa using (integral_re hψc).symm
   have hpsi0 : 0 < (psiHat 0).re := by
@@ -287,12 +287,14 @@ private def psiShift (w : ℝ) : 𝓢(ℝ, ℂ) := by
 private lemma psiShift_apply (w x : ℝ) : psiShift w x = ψ (x + w) := rfl
 
 private lemma fourier_psiShift (w u : ℝ) :
-    (𝓕 (psiShift w : ℝ → ℂ)) u = e (w * u) * psiHat u := by
+    (𝓕 (psiShift w : ℝ → ℂ)) u =
+      (Real.fourierChar (w * u) : ℂ) * psiHat u := by
   have hcoe : (psiShift w : ℝ → ℂ) = fun x : ℝ => (ψ (x + w) : ℂ) := by
     ext x
     exact_mod_cast psiShift_apply w x
   rw [hcoe, Real.fourier_real_eq]
-  have hpsi : psiHat u = ∫ x : ℝ, e (-(x * u)) * (ψ x : ℂ) := by
+  have hpsi : psiHat u =
+      ∫ x : ℝ, (Real.fourierChar (-(x * u)) : ℂ) * (ψ x : ℂ) := by
     simp only [psiHat]
     apply integral_congr_ae
     filter_upwards with x
@@ -300,7 +302,7 @@ private lemma fourier_psiShift (w u : ℝ) :
   rw [hpsi]
   have ht := congr_fun
     (Fourier.fourierIntegral_comp_add_right 𝐞 volume (fun x : ℝ => (ψ x : ℂ)) w) u
-  simpa [Fourier.fourierIntegral_def, Circle.smul_def, e, Real.fourierChar_apply] using ht
+  simpa [Fourier.fourierIntegral_def, Circle.smul_def, Real.fourierChar_apply] using ht
 
 private lemma psiShift_inner_eq_zero {v w : ℝ} (hvw : 1 ≤ |v - w|) :
     ∫ x : ℝ, inner ℂ (psiShift v x) (psiShift w x) = 0 := by
@@ -356,7 +358,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
     (hsep : IsSeparatedFamily (1 / N) ξ) :
     ∫ t : ℝ, expSumSq a ξ t * ‖psiHat ((t - t₀) / N)‖ ^ 2 = N := by
-  let c : Fin R → ℂ := fun r => a r * e (ξ r * t₀)
+  let c : Fin R → ℂ := fun r => a r * (Real.fourierChar (ξ r * t₀) : ℂ)
   let G : 𝓢(ℝ, ℂ) := ∑ r, c r • psiShift (N * ξ r)
   have hfourier (u : ℝ) :
       (𝓕 G : 𝓢(ℝ, ℂ)) u = expSum a ξ (t₀ + N * u) * psiHat u := by
@@ -374,13 +376,13 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     simp_rw [SchwartzMap.smul_apply, smul_eq_mul]
     have hshift (r : Fin R) :
         SchwartzMap.fourierTransformCLM ℂ (psiShift (N * ξ r)) u =
-          e ((N * ξ r) * u) * psiHat u := by
+          (Real.fourierChar ((N * ξ r) * u) : ℂ) * psiHat u := by
       rw [SchwartzMap.fourierTransformCLM_apply]
       rw [SchwartzMap.fourier_coe]
       exact fourier_psiShift (N * ξ r) u
     simp_rw [hshift]
-    rw [show (∑ r, c r * (e ((N * ξ r) * u) * psiHat u)) =
-        (∑ r, c r * e ((N * ξ r) * u)) * psiHat u by
+    rw [show (∑ r, c r * ((Real.fourierChar ((N * ξ r) * u) : ℂ) * psiHat u)) =
+        (∑ r, c r * (Real.fourierChar ((N * ξ r) * u) : ℂ)) * psiHat u by
       rw [Finset.sum_mul]
       apply Finset.sum_congr rfl
       intro r _
@@ -390,11 +392,15 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     intro r _
     simp only [c]
     calc
-      a r * e (ξ r * t₀) * e ((N * ξ r) * u) =
-          a r * (e (ξ r * t₀) * e ((N * ξ r) * u)) := by ring
-      _ = a r * e (ξ r * (t₀ + N * u)) := by
-        rw [← e_add]
+      a r * (Real.fourierChar (ξ r * t₀) : ℂ) *
+          (Real.fourierChar ((N * ξ r) * u) : ℂ) =
+          a r * ((Real.fourierChar (ξ r * t₀) : ℂ) *
+            (Real.fourierChar ((N * ξ r) * u) : ℂ)) := by ring
+      _ = a r * (Real.fourierChar (ξ r * (t₀ + N * u)) : ℂ) := by
+        simp only [Real.fourierChar_apply]
+        rw [← Complex.exp_add]
         congr 2
+        push_cast
         ring
   have hG_toLp :
       G.toLp 2 = ∑ r, c r • (psiShift (N * ξ r)).toLp 2 := by
@@ -403,7 +409,7 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   have hG_norm : ‖G.toLp 2‖ ^ 2 = 1 := by
     have horth := (psiShift_orthonormal ξ N hN hsep).inner_sum c c Finset.univ
     have hc_norm : ∑ r, ‖c r‖ ^ 2 = 1 := by
-      simpa only [c, norm_mul, norm_e, mul_one] using hnorm
+      simpa only [c, norm_mul, Circle.norm_coe, mul_one] using hnorm
     have hsum_norm :
         ‖∑ r, c r • (psiShift (N * ξ r)).toLp 2‖ ^ 2 = ∑ r, ‖c r‖ ^ 2 := by
       calc
@@ -461,13 +467,17 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- Goal 2 at scale M then gives c·∫_J F ≤ M ≪ψ N.
 -- ============================================================
 
-theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
-    (N : ℝ) (hN : 0 < N)
-    (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : IsSeparatedFamily (1 / N) ξ) :
-    ∃ C : ℝ, 0 < C ∧ ∀ j₀ : ℝ,
+theorem goal3 :
+    ∃ C : ℝ, 0 < C ∧
+    ∀ {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ) (N : ℝ),
+    0 < N →
+    (∑ r, ‖a r‖ ^ 2 = 1) →
+    IsSeparatedFamily (1 / N) ξ →
+    ∀ j₀ : ℝ,
     ∫ t in Set.Icc j₀ (j₀ + N), expSumSq a ξ t ≤ C * N := by
   obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound
+  refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
+  intro R a ξ N hN hnorm hsep j₀
   -- Enlarge the smoothing scale so that the whole interval lies in the
   -- neighbourhood on which `psiHat_lower_bound` applies.
   set M := N * (1 + 1 / δ)
@@ -483,8 +493,6 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     apply le_trans _ (hsep r s hrs)
     apply (div_le_div_iff₀ hM hN).2
     simpa using hNM
-  refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
-  intro j₀
   set t₀ := j₀ + N / 2
   have h2 := goal2 a ξ M hM t₀ hnorm hsepM
   have hlb_J : ∀ t ∈ Set.Icc j₀ (j₀ + N),
@@ -503,7 +511,7 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     rw [hscale]
     nlinarith
   have hFcont : Continuous (expSumSq a ξ) := by
-    unfold expSumSq expSum e
+    unfold expSumSq expSum
     fun_prop
   have hweighted : Integrable (fun t : ℝ =>
       expSumSq a ξ t * ‖psiHat ((t - t₀) / M)‖ ^ 2) := by
@@ -581,7 +589,7 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     mul_nonneg (hF_nonneg p.2) (hK_nonneg p.1 p.2)
   have hF_cont : Continuous F := by
     dsimp [F]
-    unfold expSumSq expSum e
+    unfold expSumSq expSum
     fun_prop
   have hpsiHat_cont : Continuous psiHat := by
     rw [psiHat_eq_fourier]
@@ -675,9 +683,11 @@ theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --   Step 4 (t ∉ I): 0 ∉ I_t, so = ∫_{I_t} |ψ̂|² ≪ (1+d_t)^{-10}
 -- ============================================================
 
-theorem goal5 (N : ℝ) (hN : 0 < N)
-    (left right : ℝ) (hleft_right : left ≤ right) :
-    ∃ C : ℝ, 0 < C ∧ ∀ t : ℝ,
+theorem goal5 :
+    ∃ C : ℝ, 0 < C ∧
+    ∀ N : ℝ, 0 < N →
+    ∀ left right : ℝ, left ≤ right →
+    ∀ t : ℝ,
     |kernelE N left right t| ≤
     C * (1 + min (|t - left| / N) (|t - right| / N)) ^ (-(10 : ℝ)) := by
   let f : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
@@ -744,7 +754,7 @@ theorem goal5 (N : ℝ) (hN : 0 < N)
         nlinarith [mul_nonneg (sq_nonneg C₀) hq]
       _ = C * (1 + d) ^ (-(10 : ℝ)) := rfl
   refine ⟨C, hC, ?_⟩
-  intro t
+  intro N hN left right hleft_right t
   let uLower := (t - right) / N
   let uUpper := (t - left) / N
   let d := min |uUpper| |uLower|
@@ -866,21 +876,38 @@ private lemma kernelE_aestronglyMeasurable (N : ℝ) (hN : 0 < N)
 -- shifted p-series in k.  Apply this once at each endpoint of I.
 -- ============================================================
 
-theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
-    (N : ℝ) (hN : 0 < N)
-    (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : IsSeparatedFamily (1 / N) ξ)
-    (left right : ℝ) (hleft_right : left ≤ right) :
+theorem goal6 :
     ∃ C : ℝ, 0 < C ∧
+    ∀ {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ) (N : ℝ),
+    0 < N →
+    (∑ r, ‖a r‖ ^ 2 = 1) →
+    IsSeparatedFamily (1 / N) ξ →
+    ∀ left right : ℝ, left ≤ right →
     |∫ t : ℝ, expSumSq a ξ t * kernelE N left right t| ≤ C * N := by
+  obtain ⟨C₃, hC₃, hlocal_bound⟩ := goal3
+  obtain ⟨C₅, hC₅, hkernel_bound⟩ := goal5
+  let b : ℤ → ℝ := fun k => |(k : ℝ) + 1 / 2| ^ (-(10 : ℝ))
+  have hb_nonneg : ∀ k, 0 ≤ b k :=
+    fun k => Real.rpow_nonneg (abs_nonneg _) _
+  have hb_summable : Summable b := by
+    have h := (Real.summable_one_div_int_add_rpow (1 / 2) 10).2 (by norm_num)
+    apply h.congr
+    intro k
+    dsimp [b]
+    rw [Real.rpow_neg (abs_nonneg _)]
+    rw [one_div]
+  let B := ∑' k : ℤ, b k
+  have hB : 0 ≤ B := tsum_nonneg hb_nonneg
+  refine ⟨2 * C₅ * C₃ * (B + 1), by positivity, ?_⟩
+  intro R a ξ N hN hnorm hsep left right hleft_right
   let F : ℝ → ℝ := expSumSq a ξ
   have hF_nonneg : ∀ t, 0 ≤ F t := fun t => sq_nonneg _
   have hF_cont : Continuous F := by
     dsimp [F]
-    unfold expSumSq expSum e
+    unfold expSumSq expSum
     fun_prop
-  obtain ⟨C₃, hC₃, hlocal⟩ := goal3 a ξ N hN hnorm hsep
-  obtain ⟨C₅, hC₅, hE⟩ := goal5 N hN left right hleft_right
+  have hlocal := hlocal_bound a ξ N hN hnorm hsep
+  have hE := hkernel_bound N hN left right hleft_right
   let weight : ℝ → ℝ → ℝ :=
     fun c t => (1 + |t - c| / N) ^ (-(10 : ℝ))
   have hweight_nonneg : ∀ c t, 0 ≤ weight c t :=
@@ -908,18 +935,6 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   have hcell_cover : ∀ c, ⋃ k : ℤ, cell c k = Set.univ := by
     intro c
     simpa only [cell] using iUnion_Ico_add_zsmul hN c
-  let b : ℤ → ℝ := fun k => |(k : ℝ) + 1 / 2| ^ (-(10 : ℝ))
-  have hb_nonneg : ∀ k, 0 ≤ b k :=
-    fun k => Real.rpow_nonneg (abs_nonneg _) _
-  have hb_summable : Summable b := by
-    have h := (Real.summable_one_div_int_add_rpow (1 / 2) 10).2 (by norm_num)
-    apply h.congr
-    intro k
-    dsimp [b]
-    rw [Real.rpow_neg (abs_nonneg _)]
-    rw [one_div]
-  let B := ∑' k : ℤ, b k
-  have hB : 0 ≤ B := tsum_nonneg hb_nonneg
   have hcell_weight : ∀ c k t, t ∈ cell c k → weight c t ≤ b k := by
     intro c k t ht
     have ht' : c + (k : ℝ) * N ≤ t ∧ t < c + ((k : ℝ) + 1) * N := by
@@ -1078,7 +1093,6 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     filter_upwards with t
     change |F t * kernelE N left right t| ≤ F t * |kernelE N left right t|
     rw [abs_mul, abs_of_nonneg (hF_nonneg t)]
-  refine ⟨2 * C₅ * C₃ * (B + 1), by positivity, ?_⟩
   calc
     |∫ t : ℝ, expSumSq a ξ t * kernelE N left right t| =
         |∫ t : ℝ, F t * kernelE N left right t| := by rfl
@@ -1112,18 +1126,27 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --         = T + O(N)·1   (by Goal 6: |∫ F·E| ≪ N)
 --              = (T + O(N)) · ∑|aᵣ|²  (by Goal 1: WLOG)
 -- ============================================================
-theorem l2_integral_estimate {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
-    (N : ℝ) (hN : 0 < N) (hsep : IsSeparatedFamily (1 / N) ξ)
-    (left right : ℝ) (T : ℝ) (hT : T = right - left) (hleft_right : left ≤ right) :
-    ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
-    ∫ t in Set.Icc left right, ‖∑ r, a r * e (ξ r * t)‖ ^ 2 =
+theorem l2_integral_estimate :
+    ∃ C : ℝ, 0 < C ∧
+    ∀ {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ) (N : ℝ),
+    0 < N →
+    IsSeparatedFamily (1 / N) ξ →
+    ∀ left right T : ℝ,
+    T = right - left →
+    left ≤ right →
+    ∃ θ : ℝ, |θ| ≤ C ∧
+    ∫ t in Set.Icc left right,
+      ‖∑ r, a r * (Real.fourierChar (ξ r * t) : ℂ)‖ ^ 2 =
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2 := by
-  change ∃ C : ℝ, 0 < C ∧ ∃ θ : ℝ, |θ| ≤ C ∧
+  obtain ⟨C, hC, herror⟩ := goal6
+  refine ⟨C, hC, ?_⟩
+  intro R a ξ N hN hsep left right T hT hleft_right
+  change ∃ θ : ℝ, |θ| ≤ C ∧
     ∫ t in Set.Icc left right, expSumSq a ξ t =
     (T + θ * N) * ∑ r, ‖a r‖ ^ 2
   set M := ∑ r, ‖a r‖ ^ 2
   by_cases hM0 : M = 0
-  · refine ⟨1, one_pos, 0, by simp, ?_⟩
+  · refine ⟨0, by simpa using hC.le, ?_⟩
     have hsum_zero : ∑ r, ‖a r‖ ^ 2 = 0 := by
       simpa only [M] using hM0
     have hterm_zero : ∀ r, ‖a r‖ ^ 2 = 0 := by
@@ -1163,13 +1186,13 @@ theorem l2_integral_estimate {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
         Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg M), mul_pow,
         Real.sq_sqrt hMpos.le]
     have h4 := goal4 A ξ N hN hAnorm hsep left right T hT hleft_right
-    obtain ⟨C, hC, h6⟩ := goal6 A ξ N hN hAnorm hsep left right hleft_right
+    have h6 := herror A ξ N hN hAnorm hsep left right hleft_right
     set err := ∫ t : ℝ, expSumSq A ξ t * kernelE N left right t
     have hA_eq : ∫ t in Set.Icc left right, expSumSq A ξ t = T - err := by
       simpa only [err] using h4
     have herr_bd : |err| ≤ C * N := by
       simpa only [err] using h6
-    refine ⟨C, hC, -err / N, ?_, ?_⟩
+    refine ⟨-err / N, ?_, ?_⟩
     · rw [abs_div, abs_neg, abs_of_pos hN, div_le_iff₀ hN]
       exact herr_bd
     · calc

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -57,15 +57,22 @@ lemma integrable (B : BumpData) : Integrable B.ψ :=
 
 -- ∫ ψ > 0  (from proof: "ψ(t) ≥ 0 and ‖ψ‖_{L²} = 1 so ψ ≢ 0")
 lemma integral_pos (B : BumpData) : 0 < ∫ x : ℝ, B.ψ x := by
-  apply integral_pos_of_ne_zero_of_nonneg B.nonneg
-  intro h
-  have : ∫ x : ℝ, (B.ψ x) ^ 2 = 0 := by
-    calc ∫ x : ℝ, (B.ψ x) ^ 2
-        = ∫ x : ℝ, (0 : ℝ) ^ 2 := by
-          congr 1; ext x; rw [show B.ψ x = 0 from by
-            have := congr_fun h x; simp [abs_eq_zero] at this; exact this]
-      _ = 0 := by simp
-  linarith [B.l2norm]
+  have hne : ∃ x, B.ψ x ≠ 0 := by
+    by_contra h
+    push_neg at h
+    have hsquare : ∫ x : ℝ, (B.ψ x) ^ 2 = 0 := by
+      calc
+        ∫ x : ℝ, (B.ψ x) ^ 2
+            = ∫ x : ℝ, (0 : ℝ) ^ 2 := by
+              congr 1
+              ext x
+              rw [h x]
+        _ = 0 := by simp
+    linarith [B.l2norm, hsquare]
+
+  obtain ⟨x, hx⟩ := hne
+  exact integral_pos_of_integrable_nonneg_nonzero
+    B.smooth.continuous B.integrable B.nonneg hx
 
 end BumpData
 
@@ -77,10 +84,13 @@ end BumpData
 lemma goal1 {R : ℕ} (a : Fin R → ℂ) (M : ℝ) (hM : M = ∑ r, ‖a r‖ ^ 2)
     (hpos : 0 < M) :
     ∑ r, ‖(fun r => a r / (Real.sqrt M : ℂ)) r‖ ^ 2 = 1 := by
-  simp only [norm_div, Complex.norm_ofReal,
-             abs_of_nonneg (Real.sqrt_nonneg M)]
-  rw [Finset.sum_div, Real.sq_sqrt hpos.le]
-  simp [← hM, div_self (ne_of_gt hpos)]
+  simp_rw [norm_div]
+  simp only [norm_real, Real.norm_eq_abs,
+    abs_of_nonneg (Real.sqrt_nonneg M)]
+  simp_rw [div_pow]
+  rw [← Finset.sum_div]
+  rw [← hM, Real.sq_sqrt hpos.le]
+  exact div_self (ne_of_gt hpos)
 
 -- ============================================================
 -- Plancherel: ‖ψ̂‖_{L²} = ‖ψ‖_{L²} = 1

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -3,6 +3,8 @@ import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.BumpFunction.InnerProduct
 import Mathlib.Analysis.Distribution.FourierSchwartz
 import Mathlib.Analysis.InnerProductSpace.Orthonormal
+import Mathlib.Algebra.Order.Interval.Set.Group
+import Mathlib.Analysis.PSeries
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.Tactic
@@ -452,12 +454,11 @@ theorem goal2 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 -- Goal 2 at scale M then gives c·∫_J F ≤ M ≪ψ N.
 -- ============================================================
 
-theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+private theorem goal3_uniform {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
     (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
-    (hsep : IsSeparatedFamily (1 / N) ξ)
-    (a₀ : ℝ) :
-    ∃ C : ℝ, 0 < C ∧
+    (hsep : IsSeparatedFamily (1 / N) ξ) :
+    ∃ C : ℝ, 0 < C ∧ ∀ a₀ : ℝ,
     ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
   obtain ⟨c, δ, hc, hδ, hlb⟩ := psiHat_lower_bound
   -- Enlarge the smoothing scale so that the whole interval lies in the
@@ -475,6 +476,8 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     apply le_trans _ (hsep r s hrs)
     apply (div_le_div_iff₀ hM hN).2
     simpa using hNM
+  refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
+  intro a₀
   set t₀ := a₀ + N / 2
   have h2 := goal2 a ξ M hM t₀ hnorm hsepM
   have hlb_J : ∀ t ∈ Set.Icc a₀ (a₀ + N),
@@ -500,7 +503,6 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     by_contra h
     rw [integral_undef h] at h2
     linarith
-  refine ⟨(1 + 1 / δ) / c, by positivity, ?_⟩
   have hFub : c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ M := by
     calc c * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t
         = ∫ t in Set.Icc a₀ (a₀ + N), c * expSumSq a ξ t :=
@@ -526,6 +528,16 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
   apply (le_div_iff₀ hc).2
   nlinarith
 
+theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
+    (N : ℝ) (hN : 0 < N)
+    (hnorm : ∑ r, ‖a r‖ ^ 2 = 1)
+    (hsep : IsSeparatedFamily (1 / N) ξ)
+    (a₀ : ℝ) :
+    ∃ C : ℝ, 0 < C ∧
+    ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t ≤ C * N := by
+  obtain ⟨C, hC, hlocal⟩ := goal3_uniform a ξ N hN hnorm hsep
+  exact ⟨C, hC, hlocal a₀⟩
+
 -- ============================================================
 -- GOAL 4: ∫_I F = T - ∫_ℝ F·E  (Fubini identity)
 --
@@ -540,6 +552,21 @@ theorem goal3 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 def kernelE (N : ℝ) (a₀ b₀ : ℝ) (t : ℝ) : ℝ :=
   (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) -
   Set.indicator (Set.Icc a₀ b₀) (fun _ => (1 : ℝ)) t
+
+private lemma kernelAverage_eq_intervalIntegral (N : ℝ) (hN : 0 < N)
+    (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) (t : ℝ) :
+    (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2) =
+    ∫ u in (t - b₀) / N..(t - a₀) / N, ‖psiHat u‖ ^ 2 := by
+  rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hab]
+  have hchange : (fun t₀ : ℝ => ‖psiHat ((t - t₀) / N)‖ ^ 2) =
+      fun t₀ => ‖psiHat (t / N - t₀ / N)‖ ^ 2 := by
+    funext t₀
+    rw [sub_div]
+  rw [hchange]
+  simpa only [one_div, smul_eq_mul] using
+    (intervalIntegral.inv_smul_integral_comp_sub_div
+      (f := fun u : ℝ => ‖psiHat u‖ ^ 2) (a := a₀) (b := b₀) N (t / N)).trans (by
+        congr 1 <;> field_simp)
 
 theorem goal4 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N)
@@ -734,18 +761,9 @@ theorem goal5 (N : ℝ) (hN : 0 < N)
   have hd : 0 ≤ d := le_min (abs_nonneg _) (abs_nonneg _)
   have hsubst : (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) =
       ∫ u in Set.Icc Aₜ Bₜ, f u := by
-    rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hab]
-    rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hAB]
-    have hchange : (fun t₀ : ℝ => f ((t - t₀) / N)) =
-        fun t₀ => f (t / N - t₀ / N) := by
-      funext t₀
-      congr 1
-      ring
-    rw [hchange]
-    simpa only [one_div, smul_eq_mul, Aₜ, Bₜ] using
-      (intervalIntegral.inv_smul_integral_comp_sub_div
-        (f := f) (a := a₀) (b := b₀) N (t / N)).trans (by
-          congr 1 <;> field_simp)
+    simpa only [f, Aₜ, Bₜ, intervalIntegral.integral_of_le hAB,
+      integral_Icc_eq_integral_Ioc] using
+      kernelAverage_eq_intervalIntegral N hN a₀ b₀ hab t
   have hd_eq : d = min (|t - a₀| / N) (|t - b₀| / N) := by
     dsimp [d, Aₜ, Bₜ]
     rw [abs_div, abs_div, abs_of_pos hN]
@@ -815,17 +833,43 @@ theorem goal5 (N : ℝ) (hN : 0 < N)
     exact (setIntegral_mono_set hf_int.integrableOn (ae_of_all _ hf_nonneg)
       (ae_of_all _ hsubset)).trans (htail d hd)
 
+private lemma kernelE_aestronglyMeasurable (N : ℝ) (hN : 0 < N)
+    (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
+    AEStronglyMeasurable (kernelE N a₀ b₀) := by
+  let f : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
+  have hf_int : Integrable f := by
+    by_contra h
+    have hzero := psiHat_l2
+    change ∫ u : ℝ, f u = 1 at hzero
+    rw [integral_undef h] at hzero
+    norm_num at hzero
+  let P : ℝ → ℝ := fun x => ∫ u in 0..x, f u
+  have hP_cont : Continuous P :=
+    intervalIntegral.continuous_primitive (fun x y => hf_int.intervalIntegrable) 0
+  have havg : (fun t : ℝ =>
+      (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2)) =
+      fun t => P ((t - a₀) / N) - P ((t - b₀) / N) := by
+    funext t
+    rw [kernelAverage_eq_intervalIntegral N hN a₀ b₀ hab t]
+    dsimp [P]
+    exact (intervalIntegral.integral_interval_sub_left
+      hf_int.intervalIntegrable hf_int.intervalIntegrable).symm
+  have havg_cont : Continuous (fun t : ℝ =>
+      (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, ‖psiHat ((t - t₀) / N)‖ ^ 2)) := by
+    rw [havg]
+    exact (hP_cont.comp ((continuous_id.sub continuous_const).div_const N)).sub
+      (hP_cont.comp ((continuous_id.sub continuous_const).div_const N))
+  have hind_meas : AEStronglyMeasurable
+      (Set.indicator (Set.Icc a₀ b₀) (fun _ => (1 : ℝ))) :=
+    (Measurable.indicator measurable_const measurableSet_Icc).aestronglyMeasurable
+  exact havg_cont.aestronglyMeasurable.sub hind_meas
+
 -- ============================================================
--- GOAL 6: ∫_ℝ F·E ≪ N  (dyadic decomposition)
+-- GOAL 6: ∫_ℝ F·E ≪ N  (integer-cell summation)
 --
--- From handwritten proof:
---   Case 1 (N ≪ T): divide I into J_k with |J_k| = N
---     Layer ℓ: J with dist(J,∂I) ~ 2^ℓN, contains ~2^ℓ intervals
---     |E(t)| ≪ (2^ℓ)^{-10}  (by Goal 5)
---     ∫_J F ≤ CN  (by Goal 3 = eq 3.2)
---     Sum: ∑_ℓ 2^ℓ · CN · 2^{-10ℓ} = CN ∑ 2^{-9ℓ} ≪ N
---   Cases B,C (outside I): same method
---   Case 2 (T ≪ N): direct application of (3.2)
+-- Partition ℝ into intervals [c+kN,c+(k+1)N), k ∈ ℤ.  Goal 3 gives a
+-- uniform O(N) bound on every cell, while Goal 5 contributes a summable
+-- shifted p-series in k.  Apply this once at each endpoint of I.
 -- ============================================================
 
 theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
@@ -835,101 +879,235 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (a₀ b₀ : ℝ) (hab : a₀ ≤ b₀) :
     ∃ C : ℝ, 0 < C ∧
     |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t| ≤ C * N := by
-  set T := b₀ - a₀
-  obtain ⟨C₃, hC₃, hG3⟩ := goal3 a ξ N hN hnorm hsep a₀
-  obtain ⟨C₅, hC₅, hG5⟩ := goal5 N hN a₀ b₀ hab
-  -- Case 2: T ≤ N (I fits inside one interval J)
-  by_cases hTN : T ≤ N
-  · -- Direct application of Goal 3
-    refine ⟨C₃ * C₅, by positivity, ?_⟩
-    calc |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t|
-        ≤ ∫ t : ℝ, expSumSq a ξ t * |kernelE N a₀ b₀ t| := by
-          apply (abs_integral_le_integral_abs _).trans
-          apply integral_mono_ae
-          · sorry; · sorry
-          · apply ae_of_all; intro t
-            exact mul_le_mul_of_nonneg_left (le_abs_self _)
-              (by simp [expSumSq]; positivity)
-      _ ≤ ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t * C₅ := by
-          -- |E| ≤ C₅ · 1 on [a₀, a₀+N] ⊇ I
-          apply integral_mono_of_subset
-          · intro t ht
-            exact ⟨ht.1, le_trans ht.2 (by linarith)⟩
-          · apply ae_of_all; intro t
-            apply mul_le_mul_of_nonneg_left _ (by simp [expSumSq]; positivity)
-            exact le_trans (hG5 t) (by
-              apply mul_le_mul_of_nonneg_left _ hC₅.le
-              simp [Real.rpow_neg_nonpos])
-          · sorry
-      _ = C₅ * ∫ t in Set.Icc a₀ (a₀ + N), expSumSq a ξ t := by
-          rw [← integral_const_mul]; congr 1; ext t; ring
-      _ ≤ C₅ * (C₃ * N) := mul_le_mul_of_nonneg_left (hG3 a₀) hC₅.le
-      _ = C₃ * C₅ * N := by ring
-  -- Case 1: T > N (dyadic decomposition)
-  · push_neg at hTN
-    -- L = ⌈log₂(T/N)⌉ layers
-    set L := Nat.ceil (Real.log (T / N) / Real.log 2)
-    refine ⟨C₃ * C₅ * 4 / (1 - (2:ℝ)^(-(9:ℝ))), by
-      apply div_pos; positivity
-      linarith [Real.rpow_lt_one (by norm_num) (by norm_num : (0:ℝ) < 2) (by norm_num)],
-      ?_⟩
-    -- The dyadic decomposition argument
-    -- Layer ℓ: intervals J with dist(c(J),∂I) ∈ [2^ℓN, 2^{ℓ+1}N)
-    -- # intervals in layer ℓ: ≤ 2^{ℓ+1}
-    -- |E(t)| on layer ℓ: ≤ C₅ · (2^ℓ)^{-10}
-    -- ∫_J F ≤ C₃ · N  (by Goal 3)
-    -- Sum over layers: ∑_{ℓ=0}^{L} 2^{ℓ+1} · C₃N · C₅·(2^ℓ)^{-10}
-    --                = 2C₃C₅N ∑_{ℓ=0}^{L} 2^{-9ℓ}
-    --                ≤ 2C₃C₅N · 1/(1-2^{-9})
-    calc |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t|
-        ≤ ∑ ℓ in Finset.range (L + 1),
-            ∑ k in Finset.range (2^(ℓ+1)),
-            |∫ t in Set.Icc (a₀ - (k+1) * N) (a₀ - k * N),
-              expSumSq a ξ t * kernelE N a₀ b₀ t| +
-          ∑ ℓ in Finset.range (L + 1),
-            ∑ k in Finset.range (2^(ℓ+1)),
-            |∫ t in Set.Icc (b₀ + k * N) (b₀ + (k+1) * N),
-              expSumSq a ξ t * kernelE N a₀ b₀ t| := by
-          sorry -- partition ℝ into layers
-      _ ≤ ∑ ℓ in Finset.range (L + 1), (2^(ℓ+1) : ℝ) * (C₃ * N) *
-            (C₅ * (2^ℓ)^(-(10:ℝ))) +
-          ∑ ℓ in Finset.range (L + 1), (2^(ℓ+1) : ℝ) * (C₃ * N) *
-            (C₅ * (2^ℓ)^(-(10:ℝ))) := by
-          apply add_le_add
-          all_goals {
-            apply Finset.sum_le_sum; intro ℓ _
-            apply Finset.sum_le_sum_of_subset; simp
-          }
-      _ = 2 * (C₃ * C₅ * N) * ∑ ℓ in Finset.range (L + 1), (2:ℝ)^(-(9:ℝ)*ℓ)  := by
-  have hstep : ∀ ℓ : ℕ, (2^(ℓ+1) : ℝ) * (C₃ * N) * (C₅ * (2^ℓ)^(-(10:ℝ))) =
-      2 * (C₃ * C₅ * N) * (2^(-(9:ℝ)))^ℓ := by
-    intro ℓ
-    have h1 : (2 : ℝ)^(ℓ+1) = 2 * 2^ℓ := by ring
-    have h2 : ((2:ℝ)^ℓ)^(-(10:ℝ)) = ((2:ℝ)^(-(9:ℝ)))^ℓ / (2:ℝ)^ℓ := by
-      rw [← Real.rpow_natCast 2 ℓ]
-      rw [← Real.rpow_mul (by norm_num)]
-      rw [← Real.rpow_natCast 2 ℓ]
-      simp [Real.rpow_neg, mul_comm]
-    rw [h1, h2]
-    ring
-  simp_rw [hstep]
-  rw [← Finset.mul_sum]
-      -- Geometric series: ∑_{ℓ=0}^{L} 2^{-9ℓ} ≤ 1/(1-2^{-9})
-      _ ≤ 2 * (C₃ * C₅ * N) * (1 / (1 - (2:ℝ)^(-(9:ℝ)))) := by
-          apply mul_le_mul_of_nonneg_left _ (by positivity)
-          calc ∑ ℓ in Finset.range (L + 1), (2:ℝ)^(-(9:ℝ)*ℓ)
-              ≤ ∑' ℓ : ℕ, (2:ℝ)^(-(9:ℝ)*ℓ) := by
-                apply sum_le_tsum (Finset.subset_univ _)
-                · intro ℓ _; positivity
-                · apply Summable.of_nonneg_of_le
-                  · intro ℓ; positivity
-                  · intro ℓ; exact le_refl _
-                  · apply summable_geometric_of_abs_lt_one <;> norm_num
-            _ = 1 / (1 - (2:ℝ)^(-(9:ℝ))) := by
-                rw [tsum_geometric_of_abs_lt_one]
-                · norm_num
-                · norm_num
-      _ = C₃ * C₅ * 4 / (1 - (2:ℝ)^(-(9:ℝ))) * N := by ring
+  let F : ℝ → ℝ := expSumSq a ξ
+  have hF_nonneg : ∀ t, 0 ≤ F t := fun t => sq_nonneg _
+  have hF_cont : Continuous F := by
+    dsimp [F]
+    unfold expSumSq expSum e
+    fun_prop
+  obtain ⟨C₃, hC₃, hlocal⟩ := goal3_uniform a ξ N hN hnorm hsep
+  obtain ⟨C₅, hC₅, hE⟩ := goal5 N hN a₀ b₀ hab
+  let weight : ℝ → ℝ → ℝ :=
+    fun c t => (1 + |t - c| / N) ^ (-(10 : ℝ))
+  have hweight_nonneg : ∀ c t, 0 ≤ weight c t :=
+    fun c t => Real.rpow_nonneg (by positivity) _
+  have hweight_cont : ∀ c, Continuous (weight c) := by
+    intro c
+    dsimp [weight]
+    apply Continuous.rpow_const
+    · fun_prop
+    · intro t
+      left
+      positivity
+  let W : ℝ → ℝ → ℝ := fun c t => F t * weight c t
+  have hW_nonneg : ∀ c t, 0 ≤ W c t :=
+    fun c t => mul_nonneg (hF_nonneg t) (hweight_nonneg c t)
+  have hW_cont : ∀ c, Continuous (W c) :=
+    fun c => hF_cont.mul (hweight_cont c)
+  let cell : ℝ → ℤ → Set ℝ :=
+    fun c k => Set.Ico (c + k • N) (c + (k + 1) • N)
+  have hcell_meas : ∀ c k, MeasurableSet (cell c k) :=
+    fun c k => measurableSet_Ico
+  have hcell_pairwise : ∀ c, Pairwise (fun i j => Disjoint (cell c i) (cell c j)) := by
+    intro c
+    simpa only [cell] using Set.pairwise_disjoint_Ico_add_zsmul c N
+  have hcell_cover : ∀ c, ⋃ k : ℤ, cell c k = Set.univ := by
+    intro c
+    simpa only [cell] using iUnion_Ico_add_zsmul hN c
+  let b : ℤ → ℝ := fun k => |(k : ℝ) + 1 / 2| ^ (-(10 : ℝ))
+  have hb_nonneg : ∀ k, 0 ≤ b k :=
+    fun k => Real.rpow_nonneg (abs_nonneg _) _
+  have hb_summable : Summable b := by
+    have h := (Real.summable_one_div_int_add_rpow (1 / 2) 10).2 (by norm_num)
+    apply h.congr
+    intro k
+    dsimp [b]
+    rw [Real.rpow_neg (abs_nonneg _)]
+    rw [one_div]
+  let B := ∑' k : ℤ, b k
+  have hB : 0 ≤ B := tsum_nonneg hb_nonneg
+  have hcell_weight : ∀ c k t, t ∈ cell c k → weight c t ≤ b k := by
+    intro c k t ht
+    have ht' : c + (k : ℝ) * N ≤ t ∧ t < c + ((k : ℝ) + 1) * N := by
+      simpa only [cell, zsmul_eq_mul, Int.cast_add, Int.cast_one] using ht
+    let x := (t - c) / N
+    have hx_left : (k : ℝ) ≤ x := by
+      apply (le_div_iff₀ hN).2
+      dsimp [x]
+      linarith [ht'.1]
+    have hx_right : x < (k : ℝ) + 1 := by
+      apply (div_lt_iff₀ hN).2
+      dsimp [x]
+      linarith [ht'.2]
+    have hmid_pos : 0 < |(k : ℝ) + 1 / 2| := by
+      rw [abs_pos]
+      intro hk
+      have hk' : (2 : ℝ) * (k : ℝ) = -1 := by linarith
+      have hk'' : (2 * k : ℤ) = -1 := by exact_mod_cast hk'
+      omega
+    have hmid : |((k : ℝ) + 1 / 2) - x| ≤ 1 / 2 := by
+      rw [abs_le]
+      constructor <;> linarith
+    have hbase : |(k : ℝ) + 1 / 2| ≤ 1 + |x| := by
+      calc
+        |(k : ℝ) + 1 / 2| = |(((k : ℝ) + 1 / 2) - x) + x| := by ring_nf
+        _ ≤ |((k : ℝ) + 1 / 2) - x| + |x| := abs_add_le _ _
+        _ ≤ 1 / 2 + |x| := by linarith
+        _ ≤ 1 + |x| := by linarith
+    have hrpow := Real.rpow_le_rpow_of_nonpos hmid_pos hbase (by norm_num : (-(10 : ℝ)) ≤ 0)
+    have hxabs : |t - c| / N = |x| := by
+      dsimp [x]
+      rw [abs_div, abs_of_pos hN]
+    simpa only [weight, b, hxabs] using hrpow
+  have hcell_bound : ∀ c k,
+      ∫ t in cell c k, W c t ≤ b k * (C₃ * N) := by
+    intro c k
+    let s := c + k • N
+    have hend : c + (k + 1) • N = s + N := by
+      dsimp [s]
+      rw [add_smul, one_smul]
+      ring
+    have hcell_eq : cell c k = Set.Ico s (s + N) := by
+      dsimp [cell]
+      rw [hend]
+    have hWcell : IntegrableOn (W c) (cell c k) :=
+      (hW_cont c).integrableOn_Icc.mono_set (by
+        rw [hcell_eq]
+        exact Set.Ico_subset_Icc_self)
+    have hbFcell : IntegrableOn (fun t => b k * F t) (cell c k) :=
+      ((continuous_const.mul hF_cont).integrableOn_Icc).mono_set (by
+        rw [hcell_eq]
+        exact Set.Ico_subset_Icc_self)
+    have hFcell :
+        ∫ t in cell c k, F t ≤ ∫ t in Set.Icc s (s + N), F t := by
+      apply setIntegral_mono_set hF_cont.integrableOn_Icc
+        (ae_of_all _ fun t => hF_nonneg t)
+      apply ae_of_all
+      rw [hcell_eq]
+      exact Set.Ico_subset_Icc_self
+    calc
+      ∫ t in cell c k, W c t ≤ ∫ t in cell c k, b k * F t := by
+        apply setIntegral_mono_on hWcell hbFcell (hcell_meas c k)
+        intro t ht
+        dsimp [W]
+        calc
+          F t * weight c t ≤ F t * b k :=
+            mul_le_mul_of_nonneg_left (hcell_weight c k t ht) (hF_nonneg t)
+          _ = b k * F t := by ring
+      _ = b k * ∫ t in cell c k, F t := integral_const_mul _ _
+      _ ≤ b k * ∫ t in Set.Icc s (s + N), F t :=
+        mul_le_mul_of_nonneg_left hFcell (hb_nonneg k)
+      _ ≤ b k * (C₃ * N) :=
+        mul_le_mul_of_nonneg_left (hlocal s) (hb_nonneg k)
+  have hW : ∀ c, Integrable (W c) ∧ ∫ t : ℝ, W c t ≤ B * (C₃ * N) := by
+    intro c
+    have hcell_int : ∀ k, IntegrableOn (W c) (cell c k) := by
+      intro k
+      exact (hW_cont c).integrableOn_Icc.mono_set Set.Ico_subset_Icc_self
+    have hmajor_summable : Summable (fun k => b k * (C₃ * N)) :=
+      hb_summable.mul_right (C₃ * N)
+    have hsum_norm : Summable (fun k => ∫ t in cell c k, ‖W c t‖) := by
+      refine Summable.of_nonneg_of_le
+        (f := fun k => b k * (C₃ * N)) (g := fun k => ∫ t in cell c k, ‖W c t‖) ?_ ?_
+        hmajor_summable
+      · intro k
+        exact setIntegral_nonneg (hcell_meas c k) fun t _ => norm_nonneg _
+      · intro k
+        rw [show (fun t => ‖W c t‖) = W c by
+          funext t
+          exact Real.norm_of_nonneg (hW_nonneg c t)]
+        exact hcell_bound c k
+    have hsum : Summable (fun k => ∫ t in cell c k, W c t) := by
+      apply hsum_norm.congr
+      intro k
+      rw [show (fun t => ‖W c t‖) = W c by
+        funext t
+        exact Real.norm_of_nonneg (hW_nonneg c t)]
+    have hW_int : Integrable (W c) := by
+      have hu := integrableOn_iUnion_of_summable_integral_norm hcell_int hsum_norm
+      rw [hcell_cover c] at hu
+      simpa only [integrableOn_univ] using hu
+    refine ⟨hW_int, ?_⟩
+    have hpartition :
+        ∫ t : ℝ, W c t = ∑' k : ℤ, ∫ t in cell c k, W c t := by
+      rw [← setIntegral_univ, ← hcell_cover c]
+      exact integral_iUnion (hcell_meas c) (hcell_pairwise c) hW_int.integrableOn
+    rw [hpartition]
+    calc
+      ∑' k : ℤ, ∫ t in cell c k, W c t ≤ ∑' k : ℤ, b k * (C₃ * N) :=
+        hsum.tsum_le_tsum (hcell_bound c) hmajor_summable
+      _ = B * (C₃ * N) := by
+        exact hb_summable.tsum_mul_right (C₃ * N)
+  have hmin_split : ∀ t,
+      (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ)) ≤
+      weight a₀ t + weight b₀ t := by
+    intro t
+    rcases le_total (|t - a₀| / N) (|t - b₀| / N) with h | h
+    · rw [min_eq_left h]
+      dsimp [weight]
+      exact le_add_of_nonneg_right (Real.rpow_nonneg (by positivity) _)
+    · rw [min_eq_right h]
+      dsimp [weight]
+      exact le_add_of_nonneg_left (Real.rpow_nonneg (by positivity) _)
+  have hmajor : ∀ t,
+      F t * |kernelE N a₀ b₀ t| ≤ C₅ * (W a₀ t + W b₀ t) := by
+    intro t
+    calc
+      F t * |kernelE N a₀ b₀ t| ≤
+          F t * (C₅ * (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ))) :=
+        mul_le_mul_of_nonneg_left (hE t) (hF_nonneg t)
+      _ ≤ F t * (C₅ * (weight a₀ t + weight b₀ t)) :=
+        mul_le_mul_of_nonneg_left
+          (mul_le_mul_of_nonneg_left (hmin_split t) hC₅.le) (hF_nonneg t)
+      _ = C₅ * (W a₀ t + W b₀ t) := by
+        dsimp [W]
+        ring
+  have hW_a := hW a₀
+  have hW_b := hW b₀
+  have hmajor_int : Integrable (fun t => C₅ * (W a₀ t + W b₀ t)) :=
+    (hW_a.1.add hW_b.1).const_mul C₅
+  have hkernel_meas := kernelE_aestronglyMeasurable N hN a₀ b₀ hab
+  have hkernel_abs_meas : AEStronglyMeasurable
+      (fun t => |kernelE N a₀ b₀ t|) := by
+    simpa only [Real.norm_eq_abs] using hkernel_meas.norm
+  have hFEabs_meas : AEStronglyMeasurable
+      (fun t => F t * |kernelE N a₀ b₀ t|) :=
+    hF_cont.aestronglyMeasurable.mul hkernel_abs_meas
+  have hFEabs : Integrable (fun t => F t * |kernelE N a₀ b₀ t|) := by
+    apply hmajor_int.mono' hFEabs_meas
+    filter_upwards with t
+    rw [Real.norm_eq_abs, abs_of_nonneg
+      (mul_nonneg (hF_nonneg t) (abs_nonneg _))]
+    exact hmajor t
+  have hFE : Integrable (fun t => F t * kernelE N a₀ b₀ t) := by
+    apply hFEabs.mono' (hF_cont.aestronglyMeasurable.mul hkernel_meas)
+    filter_upwards with t
+    change |F t * kernelE N a₀ b₀ t| ≤ F t * |kernelE N a₀ b₀ t|
+    rw [abs_mul, abs_of_nonneg (hF_nonneg t)]
+  refine ⟨2 * C₅ * C₃ * (B + 1), by positivity, ?_⟩
+  calc
+    |∫ t : ℝ, expSumSq a ξ t * kernelE N a₀ b₀ t| =
+        |∫ t : ℝ, F t * kernelE N a₀ b₀ t| := by rfl
+    _ ≤ ∫ t : ℝ, |F t * kernelE N a₀ b₀ t| :=
+      abs_integral_le_integral_abs
+    _ = ∫ t : ℝ, F t * |kernelE N a₀ b₀ t| := by
+      congr 1
+      funext t
+      rw [abs_mul, abs_of_nonneg (hF_nonneg t)]
+    _ ≤ ∫ t : ℝ, C₅ * (W a₀ t + W b₀ t) :=
+      integral_mono hFEabs hmajor_int hmajor
+    _ = C₅ * ((∫ t : ℝ, W a₀ t) + ∫ t : ℝ, W b₀ t) := by
+      rw [integral_const_mul, integral_add hW_a.1 hW_b.1]
+    _ ≤ C₅ * (B * (C₃ * N) + B * (C₃ * N)) := by
+      gcongr
+      · exact hW_a.2
+      · exact hW_b.2
+    _ ≤ 2 * C₅ * C₃ * (B + 1) * N := by
+      calc
+        C₅ * (B * (C₃ * N) + B * (C₃ * N)) = (2 * C₅ * C₃ * N) * B := by ring
+        _ ≤ (2 * C₅ * C₃ * N) * (B + 1) :=
+          mul_le_mul_of_nonneg_left (le_add_of_nonneg_right zero_le_one) (by positivity)
+        _ = 2 * C₅ * C₃ * (B + 1) * N := by ring
 
 -- ============================================================
 -- GOAL 7: Lemma 3.1 (Assembly)
@@ -940,7 +1118,6 @@ theorem goal6 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
 --         = T + O(N)·1   (by Goal 6: |∫ F·E| ≪ N)
 --              = (T + O(N)) · ∑|aᵣ|²  (by Goal 1: WLOG)
 -- ============================================================
-
 theorem lemma3_1 {R : ℕ} (a : Fin R → ℂ) (ξ : Fin R → ℝ)
     (N : ℝ) (hN : 0 < N) (hsep : IsSeparatedFamily (1 / N) ξ)
     (a₀ b₀ : ℝ) (T : ℝ) (hT : T = b₀ - a₀) (hab : a₀ ≤ b₀) :

--- a/expdb/basic_fourier_estimates.lean
+++ b/expdb/basic_fourier_estimates.lean
@@ -656,152 +656,164 @@ theorem goal5 (N : ℝ) (hN : 0 < N)
     ∃ C : ℝ, 0 < C ∧ ∀ t : ℝ,
     |kernelE N a₀ b₀ t| ≤
     C * (1 + min (|t - a₀| / N) (|t - b₀| / N)) ^ (-(10 : ℝ)) := by
-  obtain ⟨C_d, hC_d, hdecay⟩ := psiHat_decay 12
-  refine ⟨C_d ^ 2 * 8, by positivity, ?_⟩
-  intro t
-have hint : Integrable (fun u => ‖psiHat u‖ ^ 2) := by
-    apply Integrable.mono (f := fun u => C_d * (1 + |u|)^(-(12:ℝ)))
-    · apply Integrable.const_mul
-      exact integrable_rpow_neg (by norm_num)
-    · apply ae_of_all; intro u
-      exact hdecay u
-  have hint2 : Integrable (fun u => (1 + |u|)^(-(12:ℝ))) := by
-    apply integrable_rpow_neg_abs (by norm_num : (1:ℝ) < 12)
-  -- Step 2: Substitution u = (t-t₀)/N
-  -- 1/N ∫_I |ψ̂((t-t₀)/N)|² dt₀ = ∫_{I_t} |ψ̂(u)|² du
-  have hsubst : (1 / N) * ∫ t₀ in Set.Icc a₀ b₀,
-      ‖psiHat ((t - t₀) / N)‖ ^ 2 =
-      ∫ u in Set.Icc ((t - b₀) / N) ((t - a₀) / N),
-        ‖psiHat u‖ ^ 2 := by
-    rw [one_div, ← intervalIntegral.integral_comp_sub_left
-      (fun u => ‖psiHat u‖ ^ 2) t]
-    simp [Set.uIcc_of_le (div_le_div_of_nonneg_right (by linarith) hN)]
-    congr 1 <;> [field_simp; field_simp; ring]
-  -- Tail bound: ∫_{|u|≥d} |ψ̂|² ≤ 2C²/(11(1+d)^{11}) ≪ (1+d)^{-10}
+  let f : ℝ → ℝ := fun u => ‖psiHat u‖ ^ 2
+  have hf_nonneg : ∀ u, 0 ≤ f u := fun u => sq_nonneg _
+  have hf_int : Integrable f := by
+    by_contra h
+    have hzero := psiHat_l2
+    change ∫ u : ℝ, f u = 1 at hzero
+    rw [integral_undef h] at hzero
+    norm_num at hzero
+  obtain ⟨C₀, hC₀, hdecay⟩ := psiHat_decay 6
+  let w : ℝ → ℝ := fun u => (1 + |u|) ^ (-(2 : ℝ))
+  have hw_nonneg : ∀ u, 0 ≤ w u := fun u => Real.rpow_nonneg (by positivity) _
+  have hw_int : Integrable w := by
+    simpa only [w, Real.norm_eq_abs] using
+      (integrable_one_add_norm (E := ℝ) (μ := volume) (r := 2) (by norm_num))
+  let A := ∫ u : ℝ, w u
+  have hA : 0 ≤ A := integral_nonneg hw_nonneg
+  let C := C₀ ^ 2 * (A + 1)
+  have hC : 0 < C := by
+    dsimp [C]
+    positivity
   have htail : ∀ d : ℝ, 0 ≤ d →
-      ∫ u in {u : ℝ | d ≤ |u|}, ‖psiHat u‖ ^ 2 ≤
-      C_d ^ 2 * 8 * (1 + d) ^ (-(10 : ℝ)) := by
+      ∫ u in {u : ℝ | d ≤ |u|}, f u ≤ C * (1 + d) ^ (-(10 : ℝ)) := by
     intro d hd
-    calc ∫ u in {u | d ≤ |u|}, ‖psiHat u‖ ^ 2
-        ≤ C_d ^ 2 * ∫ u in {u | d ≤ |u|}, (1 + |u|) ^ (-(12 : ℝ)) := by
-          apply set_integral_mono_ae
-          · exact hint
-          · exact (Integrable.const_mul hint2_)
-          · apply ae_of_all; intro u
-            have := hdecay u
-            nlinarith [norm_nonneg (psiHat u), sq_nonneg (‖psiHat u‖)]
-      -- ∫_{|u|≥d} (1+|u|)^{-12} du = 2/(11(1+d)^{11})
-      _ ≤ C_d ^ 2 * (8 * (1 + d) ^ (-(10 : ℝ))) := by
-          apply mul_le_mul_of_nonneg_left _ (by positivity)
-          have hcalc : ∫ u in Set.Ici d, (1 + u) ^ (-(12 : ℝ)) =
-              (1/11) * (1 + d) ^ (-(11 : ℝ)) := by
-            simp [MeasureTheory.integral_Ici_rpow_of_lt (by norm_num : -(12:ℝ) < -1)]
-            ring
-          calc ∫ u in {u : ℝ | d ≤ |u|}, (1 + |u|) ^ (-(12 : ℝ))
-              ≤ 2 * ∫ u in Set.Ici d, (1 + u) ^ (-(12 : ℝ)) := by
-                rw [show {u : ℝ | d ≤ |u|} = Set.Ici d ∪ Set.Iic (-d) from by
-                  ext u; simp [abs_le, le_abs]]
-                rw [integral_union (by simp; intro a h1 h2; linarith)
-                  measurableSet_Ici]
-                · have hsym : ∫ u in Set.Iic (-d), (1 + |u|) ^ (-(12 : ℝ)) =
-                      ∫ u in Set.Ici d, (1 + u) ^ (-(12 : ℝ)) := by
-                    rw [← integral_comp_neg (f := fun u => (1 + |u|)^(-(12:ℝ)))]
-                    simp [abs_neg]
-                    congr 1; ext u
-                    rw [show Set.Ici d = {u | d ≤ u} from rfl]
-                    simp [abs_of_nonneg]
-                  rw [show (∫ u in Set.Ici d, (1 + |u|)^(-(12:ℝ))) =
-                      ∫ u in Set.Ici d, (1+u)^(-(12:ℝ)) from by
-                    congr 1; ext u
-                    congr 2; exact abs_of_nonneg (le_trans hd (Set.mem_Ici.mp ‹_›))]
-                  linarith [integral_nonneg (fun u => by positivity)]
-                · sorry; · sorry
-            _ = 2 * (1/11) * (1+d)^(-(11:ℝ)) := by rw [hcalc]; ring
-            _ ≤ 8 * (1+d)^(-(10:ℝ)) := by
-                have h1d : 1 + d ≥ 1 := by linarith
-                nlinarith [Real.rpow_le_rpow_of_exponent_ge h1d
-                  (by norm_num : -(11:ℝ) ≤ -(10:ℝ))]
-      _ = C_d ^ 2 * 8 * (1 + d) ^ (-(10 : ℝ)) := by ring
-  -- Set d_t = dist(t, ∂I)/N
-  set d_t := min (|t - a₀| / N) (|t - b₀| / N)
-  -- Case analysis: t ∈ I or t ∉ I
-  by_cases htI : t ∈ Set.Icc a₀ b₀
-  · -- STEP 3: t ∈ I → 0 ∈ I_t
-    -- |E(t)| = |∫_{ℝ\I_t} |ψ̂|²| ≤ ∫_{|u|≥d_t} |ψ̂|²
-    have hind : Set.indicator (Set.Icc a₀ b₀) (fun _ => (1:ℝ)) t = 1 :=
-      Set.indicator_of_mem htI _
-    simp only [kernelE, hind, hsubst]
-    -- 0 ∈ I_t because t ∈ [a₀,b₀]
-    have h0_in : (0:ℝ) ∈ Set.Icc ((t-b₀)/N) ((t-a₀)/N) := by
+    let q := (1 + d) ^ (-(10 : ℝ))
+    have hq : 0 ≤ q := Real.rpow_nonneg (by positivity) _
+    have hmajorant : Integrable (fun u => C₀ ^ 2 * q * w u) :=
+      by simpa only [mul_assoc] using (hw_int.const_mul q).const_mul (C₀ ^ 2)
+    calc
+      ∫ u in {u : ℝ | d ≤ |u|}, f u ≤
+          ∫ u in {u : ℝ | d ≤ |u|}, C₀ ^ 2 * q * w u := by
+        apply setIntegral_mono_on hf_int.integrableOn hmajorant.integrableOn
+          (measurableSet_le measurable_const (continuous_abs.measurable))
+        intro u hu
+        change d ≤ |u| at hu
+        have hsquare : f u ≤ C₀ ^ 2 * (1 + |u|) ^ (-(12 : ℝ)) := by
+          dsimp [f]
+          have hd' := hdecay u
+          have hp : 0 ≤ (1 + |u|) ^ (-(6 : ℝ)) := Real.rpow_nonneg (by positivity) _
+          have hp_sq : (1 + |u|) ^ (-(12 : ℝ)) =
+              ((1 + |u|) ^ (-(6 : ℝ))) ^ 2 := by
+            rw [pow_two, ← Real.rpow_add (by positivity)]
+            norm_num
+          calc
+            ‖psiHat u‖ ^ 2 ≤ (C₀ * (1 + |u|) ^ (-(6 : ℝ))) ^ 2 :=
+              (sq_le_sq₀ (norm_nonneg _) (mul_nonneg hC₀.le hp)).2 hd'
+            _ = C₀ ^ 2 * ((1 + |u|) ^ (-(6 : ℝ))) ^ 2 := by ring
+            _ = C₀ ^ 2 * (1 + |u|) ^ (-(12 : ℝ)) := by rw [hp_sq]
+        have hfactor : (1 + |u|) ^ (-(12 : ℝ)) =
+            w u * (1 + |u|) ^ (-(10 : ℝ)) := by
+          dsimp [w]
+          rw [← Real.rpow_add (by positivity)]
+          norm_num
+        have hmono : (1 + |u|) ^ (-(10 : ℝ)) ≤ q := by
+          dsimp [q]
+          exact Real.rpow_le_rpow_of_nonpos (by positivity) (by linarith) (by norm_num)
+        calc
+          f u ≤ C₀ ^ 2 * (1 + |u|) ^ (-(12 : ℝ)) := hsquare
+          _ = C₀ ^ 2 * (w u * (1 + |u|) ^ (-(10 : ℝ))) := by rw [hfactor]
+          _ ≤ C₀ ^ 2 * (w u * q) := by gcongr
+          _ = C₀ ^ 2 * q * w u := by ring
+      _ ≤ ∫ u : ℝ, C₀ ^ 2 * q * w u :=
+        setIntegral_le_integral hmajorant (ae_of_all _ fun u => by positivity)
+      _ = C₀ ^ 2 * q * A := by simp only [integral_const_mul, A]
+      _ ≤ C * q := by
+        dsimp [C]
+        nlinarith [mul_nonneg (sq_nonneg C₀) hq]
+      _ = C * (1 + d) ^ (-(10 : ℝ)) := rfl
+  refine ⟨C, hC, ?_⟩
+  intro t
+  let Aₜ := (t - b₀) / N
+  let Bₜ := (t - a₀) / N
+  let d := min |Bₜ| |Aₜ|
+  have hAB : Aₜ ≤ Bₜ := by
+    dsimp [Aₜ, Bₜ]
+    exact div_le_div_of_nonneg_right (sub_le_sub_left hab t) hN.le
+  have hd : 0 ≤ d := le_min (abs_nonneg _) (abs_nonneg _)
+  have hsubst : (1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) =
+      ∫ u in Set.Icc Aₜ Bₜ, f u := by
+    rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hab]
+    rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hAB]
+    have hchange : (fun t₀ : ℝ => f ((t - t₀) / N)) =
+        fun t₀ => f (t / N - t₀ / N) := by
+      funext t₀
+      congr 1
+      ring
+    rw [hchange]
+    simpa only [one_div, smul_eq_mul, Aₜ, Bₜ] using
+      (intervalIntegral.inv_smul_integral_comp_sub_div
+        (f := f) (a := a₀) (b := b₀) N (t / N)).trans (by
+          congr 1 <;> field_simp)
+  have hd_eq : d = min (|t - a₀| / N) (|t - b₀| / N) := by
+    dsimp [d, Aₜ, Bₜ]
+    rw [abs_div, abs_div, abs_of_pos hN]
+  by_cases ht : t ∈ Set.Icc a₀ b₀
+  · have hAₜ : Aₜ ≤ 0 := by
+      dsimp [Aₜ]
+      exact div_nonpos_of_nonpos_of_nonneg (sub_nonpos.mpr ht.2) hN.le
+    have hBₜ : 0 ≤ Bₜ := by
+      dsimp [Bₜ]
+      exact div_nonneg (sub_nonneg.mpr ht.1) hN.le
+    have hsubset : (Set.Icc Aₜ Bₜ)ᶜ ⊆ {u : ℝ | d ≤ |u|} := by
+      intro u hu
+      simp only [Set.mem_compl_iff, Set.mem_Icc, not_and_or, not_le] at hu
+      simp only [Set.mem_setOf_eq]
+      rcases hu with hu | hu
+      · rw [abs_of_nonpos (hu.le.trans hAₜ)]
+        exact (min_le_right |Bₜ| |Aₜ|).trans (by
+          rw [abs_of_nonpos hAₜ]
+          linarith)
+      · rw [abs_of_nonneg (hBₜ.trans hu.le)]
+        exact (min_le_left |Bₜ| |Aₜ|).trans (by
+          rw [abs_of_nonneg hBₜ]
+          linarith)
+    have hcomp : (∫ u in Set.Icc Aₜ Bₜ, f u) - 1 =
+        -(∫ u in (Set.Icc Aₜ Bₜ)ᶜ, f u) := by
+      rw [setIntegral_compl measurableSet_Icc hf_int, psiHat_l2]
+      ring
+    rw [kernelE, Set.indicator_of_mem ht]
+    change |(1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) - 1| ≤ _
+    rw [hsubst, hcomp, abs_neg, abs_of_nonneg
+      (setIntegral_nonneg measurableSet_Icc.compl fun u _ => hf_nonneg u)]
+    rw [← hd_eq]
+    exact (setIntegral_mono_set hf_int.integrableOn (ae_of_all _ hf_nonneg)
+      (ae_of_all _ hsubset)).trans (htail d hd)
+  · have hzero : (0 : ℝ) ∉ Set.Icc Aₜ Bₜ := by
+      intro h0
+      apply ht
       constructor
-      · apply div_nonpos_of_nonpos_of_nonneg <;> linarith [htI.2]
-      · apply div_nonneg <;> linarith [htI.1]
-    -- ∫_{I_t} = ∫_ℝ - ∫_{ℝ\I_t} = 1 - ∫_{ℝ\I_t}
-    rw [psiHat_l2.symm]
-    rw [← integral_add_compl measurableSet_Icc (by sorry)]
-    simp only [add_sub_cancel_left]
-    rw [abs_neg]
-    calc |∫ u in (Set.Icc _ _)ᶜ, ‖psiHat u‖^2|
-        ≤ ∫ u in (Set.Icc _ _)ᶜ, ‖psiHat u‖^2 :=
-          le_abs_self _
-      _ ≤ ∫ u in {u | d_t ≤ |u|}, ‖psiHat u‖^2 := by
-          apply set_integral_mono_set
-          · exact fun u => sq_nonneg _
-          -- ℝ\I_t ⊆ {|u| ≥ d_t} because 0 ∈ I_t
-          · apply ae_of_all; intro u hu
-            simp only [Set.mem_compl_iff, Set.mem_Icc, not_and_or, not_le] at hu
-            simp only [Set.mem_setOf_eq]
-            -- Geometric argument: since 0 ∈ I_t, u outside I_t means |u| ≥ d_t
-            cases hu with
-            | inl h =>
-              rw [abs_of_nonpos (le_of_lt h)]
-              simp [d_t]; constructor
-              · linarith [h, h0_in.1]
-              · linarith [h, (t - b₀)/N |>.neg_le_abs]
-            | inr h =>
-              rw [abs_of_pos h]
-              simp [d_t]; constructor
-              · linarith [h0_in.2]
-              · linarith [h, le_abs_self ((t-b₀)/N)]
-      _ ≤ C_d^2 * 8 * (1 + d_t)^(-(10:ℝ)) :=
-          htail d_t (by simp [d_t]; positivity)
-  · -- STEP 4: t ∉ I → 0 ∉ I_t
-    have hind : Set.indicator (Set.Icc a₀ b₀) (fun _ => (1:ℝ)) t = 0 :=
-      Set.indicator_of_not_mem htI _
-    simp only [kernelE, hind, hsubst, sub_zero]
-    rw [abs_of_nonneg (integral_nonneg (fun u => sq_nonneg _))]
-    -- 0 ∉ I_t because t ∉ [a₀,b₀]
-    have h0_out : (0:ℝ) ∉ Set.Icc ((t-b₀)/N) ((t-a₀)/N) := by
-      simp only [Set.mem_Icc, not_and_or, not_le]
-      cases Set.not_mem_Icc.mp htI with
-      | inl h => right; apply div_pos_of_neg_of_neg <;> linarith
-      | inr h => left; apply div_neg_of_pos_of_neg <;> linarith
-    calc ∫ u in Set.Icc ((t-b₀)/N) ((t-a₀)/N), ‖psiHat u‖^2
-        ≤ ∫ u in {u | d_t ≤ |u|}, ‖psiHat u‖^2 := by
-          apply set_integral_mono_set
-          · exact fun u => sq_nonneg _
-          -- I_t ⊆ {|u| ≥ d_t} because 0 ∉ I_t
-          · apply ae_of_all; intro u hu
-            simp only [Set.mem_setOf_eq]
-            simp only [Set.mem_Icc] at hu
-            -- Geometric: 0 ∉ I_t → I_t entirely on one side → |u| ≥ d_t
-            cases Set.not_mem_Icc.mp h0_out with
-            | inl h =>
-              -- I_t is entirely negative
-              rw [abs_of_nonpos (le_trans hu.2 (le_of_lt h))]
-              simp [d_t]
-              constructor
-              · linarith [hu.1]
-              · linarith [hu.2, h]
-            | inr h =>
-              -- I_t is entirely positive
-              rw [abs_of_nonneg (le_trans (le_of_lt (lt_of_not_le h)) hu.1)]
-              simp [d_t]
-              constructor
-              · linarith [hu.1, h]
-              · linarith [hu.2]
-      _ ≤ C_d^2 * 8 * (1 + d_t)^(-(10:ℝ)) :=
-          htail d_t (by simp [d_t]; positivity)
+      · apply sub_nonneg.mp
+        rcases div_nonneg_iff.mp h0.2 with h | h
+        · exact h.1
+        · exact (hN.not_ge h.2).elim
+      · apply sub_nonpos.mp
+        rcases div_nonpos_iff.mp h0.1 with h | h
+        · exact (hN.not_ge h.2).elim
+        · exact h.1
+    have hsubset : Set.Icc Aₜ Bₜ ⊆ {u : ℝ | d ≤ |u|} := by
+      intro u hu
+      rcases hu with ⟨hu1, hu2⟩
+      simp only [Set.mem_setOf_eq]
+      have hzero' : 0 < Aₜ ∨ Bₜ < 0 := by
+        simpa only [Set.mem_Icc, not_and_or, not_le] using hzero
+      rcases hzero' with hApos | hBneg
+      · rw [abs_of_nonneg (hApos.le.trans hu1)]
+        exact (min_le_right |Bₜ| |Aₜ|).trans (by
+          rw [abs_of_nonneg hApos.le]
+          linarith)
+      · rw [abs_of_nonpos (hu2.trans hBneg.le)]
+        exact (min_le_left |Bₜ| |Aₜ|).trans (by
+          rw [abs_of_nonpos hBneg.le]
+          linarith)
+    rw [kernelE, Set.indicator_of_notMem ht]
+    change |(1 / N) * (∫ t₀ in Set.Icc a₀ b₀, f ((t - t₀) / N)) - 0| ≤ _
+    rw [sub_zero, hsubst, abs_of_nonneg
+      (setIntegral_nonneg measurableSet_Icc fun u _ => hf_nonneg u)]
+    rw [← hd_eq]
+    exact (setIntegral_mono_set hf_int.integrableOn (ae_of_all _ hf_nonneg)
+      (ae_of_all _ hsubset)).trans (htail d hd)
 
 -- ============================================================
 -- GOAL 6: ∫_ℝ F·E ≪ N  (dyadic decomposition)


### PR DESCRIPTION
- Updated expdb.lean to import the two files corresponding to Chapter 2 & 3 rather than the example lean file.
- Generalised some of the definition in basic.lean and removed the definitions/notations that are already available from Mathlib.
- Fixed the proof of Lemma 3.1 removing all sorries and other errors. While it follows the existing six goals approach to proving the lemma, I decided to use an explicit bump function available from Mathlib instead of defining general properties of a suitable function \psi.