### PR TITLE
fix: RationalFunction errors and update_mathlib.sh errexit

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -911,7 +911,7 @@ class RationalFunction:
             r.num = self.num * other.den + self.den * other.num
             r.den = self.den * other.den
             return r
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def subtract(self, other):
         r = RationalFunction([])

--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -748,7 +748,7 @@ class RationalFunction:
     # from highest degree to lowest degree) for both the numerator and denominator
     def __init__(self, num_coeffs, den_coeffs=None):
 
-        if den_coeffs == None:
+        if den_coeffs is None:
             den_coeffs = [1]
 
         num = 0

--- a/scripts/update_mathlib.sh
+++ b/scripts/update_mathlib.sh
@@ -1,5 +1,7 @@
 # Update Mathlib and the Lean toolchain.
 
+set -euo pipefail # stop if any command fails
+
 # Download the latest lean-toolchain file from the Mathlib4 repository
 curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
 


### PR DESCRIPTION
## Summary
- `RationalFunction.add`: `raise NotImplementedError()` instead of returning the exception object.
- `RationalFunction.__init__`: compare `den_coeffs is None`.
- `scripts/update_mathlib.sh`: `set -euo pipefail` so a failed step stops the script.

Branches: `fix/rational-function-raise-notimplemented`, `fix/rational-function-none-compare`, `fix/update-mathlib-errexit`.

## Test plan
- [x] `scripts/check_whitespace.py`
- [ ] CI whitespace / blueprint workflows

Made with [Cursor](https://cursor.com)