### PR TITLE
fix: Region.project IndexError and RationalFunction scalar div

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -941,8 +941,8 @@ class RationalFunction:
     def div(self, other):
         r = RationalFunction([])
         if isinstance(other, numbers.Number):
-            r.num = self.num * other
-            r.den = self.den
+            r.num = self.num
+            r.den = self.den * other
             return r
         if isinstance(other, RationalFunction):
             r.num = self.num * other.den

--- a/blueprint/src/python/region.py
+++ b/blueprint/src/python/region.py
@@ -266,7 +266,7 @@ class Region:
             ps = [c.project(dims) for c in self.child]
             ps = [p for p in ps if p is not None]
             if len(ps) == 0: return None
-            if len(ps) == 1: return ps[1]
+            if len(ps) == 1: return ps[0]
             return Region(Region_Type.INTERSECT, ps)
 
         # In particular, complements are not yet supported.


### PR DESCRIPTION
## Summary
- `Region.project` for `INTERSECT` used `return ps[1]` when exactly one projected child remained, raising `IndexError`. Match the UNION branch and return `ps[0]`.
- `RationalFunction.div` by a scalar multiplied the numerator; it now scales the denominator (`f.div(2)` is `1/2`, not `2`).

Independent of #188–#189.

## Test plan
- [x] `RationalFunction([1]).div(2)` yields numerator `1`, denominator `2`
- [ ] Spot-check `Region.project` on a one-child intersection


Made with [Cursor](https://cursor.com)