### PR TITLE
Fix MathJax include path and deprecated CDN on the homepage

### DIFF
--- a/home_page/_includes/head-custom.html
+++ b/home_page/_includes/head-custom.html
@@ -1,0 +1,5 @@
+{% comment %}
+  Project override of the Cayman theme head-custom include.
+  Loads MathJax when page.usemathjax is set.
+{% endcomment %}
+{% include mathjax.html %}

--- a/home_page/_includes/mathjax.html
+++ b/home_page/_includes/mathjax.html
@@ -1,17 +1,17 @@
 <!-- Check if the current page requires MathJax support -->
 {% if page.usemathjax %}
-  <!-- MathJax configuration script -->
+  <!-- MathJax configuration (MathJax 2.x API) -->
   <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
       TeX: {
         equationNumbers: {
-          autoNumber: "AMS"  <!-- Automatically number equations using AMS style -->
+          autoNumber: "AMS"
         }
       }
     });
   </script>
-  <!-- Load MathJax library asynchronously from the CDN -->
+  <!-- Load MathJax from cdnjs (cdn.mathjax.org/latest is a deprecated stub) -->
   <script type="text/javascript" async
-    src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
   </script>
 {% endif %}


### PR DESCRIPTION
## Summary
- MathJax lived under `home_page/_include/` (singular). Jekyll only loads from `_includes/`, so the partial was invisible.
- The Cayman layout includes `head-custom.html`; add a project override that pulls in MathJax when `page.usemathjax` is set (e.g. `index.md`).
- Point the script at cdnjs MathJax 2.7.9 instead of the deprecated `cdn.mathjax.org/.../latest` stub, and remove an HTML comment that was embedded inside the config `<script>` (invalid JavaScript).

## Test plan
- [ ] Confirm `home_page/_includes/{mathjax,head-custom}.html` exist and `_include/` is gone
- [ ] CI blueprint/homepage job passes
- [ ] After deploy: view-source on https://teorth.github.io/expdb/ shows the cdnjs MathJax script when `usemathjax` is true

Made with [Cursor](https://cursor.com)