### PR TITLE
Reject infinite polytopes in Polytope.try_union

### DIFF
--- a/blueprint/src/python/polytope.py
+++ b/blueprint/src/python/polytope.py
@@ -245,15 +245,24 @@ class Polytope:
     # A. Bemporad et al. "Convexity recognition of the union of polyhedra" (2001)
     # Algorithm 4.1
     #
-    # This implementation only works with finite polytopes - for infinite polytopes
-    # the wrong result is returned. See e.g. the test cases in test_polytope.
-    # TODO: implement check and error for infinite polytopes.
+    # This implementation only works with finite polytopes. Extreme rays are
+    # ignored by the vertex-only feasibility checks below, so unbounded inputs
+    # previously produced silently incorrect envelopes; reject them instead.
     def try_union(polys):
         if not isinstance(polys, list) or len(polys) == 0:
             return None
 
         if len(polys) == 1:
             return polys[0]
+
+        for p in polys:
+            if p.rays is None:
+                p.compute_V_rep()
+            if p.rays:
+                raise ValueError(
+                    "Polytope.try_union only supports finite polytopes "
+                    "(an input has extreme rays)"
+                )
 
         # Performance optimisation: see if intersection is nonempty first. This
         # is relative cheap compared to the full union operation, since it only

--- a/blueprint/src/python/tests/test_polytope.py
+++ b/blueprint/src/python/tests/test_polytope.py
@@ -307,6 +307,19 @@ def run_union_test():
     long_line = Polytope.rect((frac(1,2), frac(1,2)), (-1, 2))
     assert Polytope.try_union([square, long_line]) is None
 
+    # Unbounded inputs must be rejected: the union algorithm only inspects
+    # vertices, so extreme rays would otherwise yield a wrong envelope.
+    half_strip = Polytope([
+        [0, 1, 0],   # x >= 0
+        [0, 0, 1],   # y >= 0
+        [-1, 0, 1],  # y <= 1
+    ])
+    try:
+        Polytope.try_union([half_strip, square])
+        assert False, "expected ValueError for infinite polytope"
+    except ValueError as e:
+        assert "finite polytopes" in str(e)
+
 def run_union_3d_test():
     # Higher dimensional polytope test
     # ['1 - x >= 0', '8 - 14x + 5/2y - z >= 0', '8 - 4x - z >= 0', '3 - y >= 0', '-34/3 + 32/3x + z >= 0']


### PR DESCRIPTION
## Summary
- `Polytope.try_union` only inspected vertices when deciding envelope vs negated constraints. Extreme rays were ignored, so unbounded inputs could produce a silently wrong finite envelope (noted in-code as a TODO).
- Reject any input with extreme rays via `ValueError`, and add a regression test covering a half-infinite strip.

## Test plan
- [ ] `python -c` / `tests/test_polytope.py` union section: finite unions unchanged; half-strip ∪ square raises `ValueError` mentioning finite polytopes
- [ ] CI passes (blueprint path change)

Made with [Cursor](https://cursor.com)