### PR TITLE
Fix the Python test suite and the zero-density pipeline

### DIFF
--- a/blueprint/src/python/polytope.py
+++ b/blueprint/src/python/polytope.py
@@ -247,7 +247,8 @@ class Polytope:
     #
     # This implementation only works with finite polytopes. Extreme rays are
     # ignored by the vertex-only feasibility checks below, so unbounded inputs
-    # previously produced silently incorrect envelopes; reject them instead.
+    # would produce silently incorrect envelopes; report them as not a polytope
+    # instead, which leaves the caller with the pieces it started with.
     def try_union(polys):
         if not isinstance(polys, list) or len(polys) == 0:
             return None
@@ -259,10 +260,7 @@ class Polytope:
             if p.rays is None:
                 p.compute_V_rep()
             if p.rays:
-                raise ValueError(
-                    "Polytope.try_union only supports finite polytopes "
-                    "(an input has extreme rays)"
-                )
+                return None
 
         # Performance optimisation: see if intersection is nonempty first. This
         # is relative cheap compared to the full union operation, since it only

--- a/blueprint/src/python/tests/test_affine2.py
+++ b/blueprint/src/python/tests/test_affine2.py
@@ -1,7 +1,16 @@
 # Test cases for Affine2 implementation
 from fractions import Fraction as frac
-from large_values import large_values as lv
+from functions import Affine2, Piecewise
 from polytope import *
+
+
+# The pointwise minimum of a list of affine functions over a common domain,
+# as a Piecewise function.
+def min_of(fns, region):
+    f = Piecewise([Affine2(fns[0], region, 0)])
+    for i in range(1, len(fns)):
+        f = f.min_with(Piecewise([Affine2(fns[i], region, i)]))
+    return f
 
 
 def test_edge_case():
@@ -13,7 +22,14 @@ def test_edge_case():
         [3, -6, 2]
     ]
     region = Polytope.rect((frac(1,2), frac(1)), (frac(1), frac(3)))
-    m = lv.max_of(fns, region)
-    assert m.check((1/2, 1), (1,3))
+    m = min_of(fns, region)
+    # The pieces tile the region without overlapping
+    assert m.check((frac(1,2), frac(1)), (frac(1), frac(3)))
+    # and each piece really carries the minimum of the five functions
+    for i in range(11):
+        for j in range(11):
+            x = frac(1,2) + frac(i, 22)
+            y = frac(1) + frac(2 * j, 10)
+            assert m.at([x, y]) == min(f[0] + f[1] * x + f[2] * y for f in fns)
 
 test_edge_case()

--- a/blueprint/src/python/tests/test_polytope.py
+++ b/blueprint/src/python/tests/test_polytope.py
@@ -259,7 +259,10 @@ def run_union_test():
         ])
     assert Polytope.try_union([p1, p2]) == union
 
-    # Another test case - with a vertex at infinity (this fails)
+    # Another test case - with a vertex at infinity.  try_union decides
+    # containment from the vertices alone, so it cannot see extreme rays and
+    # reports an unbounded input as unmergeable rather than returning a wrong
+    # envelope.
     p1 = Polytope([
         [18, -22, 0],
         [12, -12, -1],
@@ -274,7 +277,7 @@ def run_union_test():
         [12, -12, -1],
         [3, 0, -1]
         ])
-    U = Polytope.try_union([p1, p2])
+    assert Polytope.try_union([p1, p2]) is None
 
     p1 = Polytope([
         [-3, 0, 2],
@@ -307,18 +310,14 @@ def run_union_test():
     long_line = Polytope.rect((frac(1,2), frac(1,2)), (-1, 2))
     assert Polytope.try_union([square, long_line]) is None
 
-    # Unbounded inputs must be rejected: the union algorithm only inspects
+    # Unbounded inputs are unmergeable: the union algorithm only inspects
     # vertices, so extreme rays would otherwise yield a wrong envelope.
     half_strip = Polytope([
         [0, 1, 0],   # x >= 0
         [0, 0, 1],   # y >= 0
         [-1, 0, 1],  # y <= 1
     ])
-    try:
-        Polytope.try_union([half_strip, square])
-        assert False, "expected ValueError for infinite polytope"
-    except ValueError as e:
-        assert "finite polytopes" in str(e)
+    assert Polytope.try_union([half_strip, square]) is None
 
 def run_union_3d_test():
     # Higher dimensional polytope test


### PR DESCRIPTION
Two things are broken on main, both easy to hit.

**`python tests/test_all.py` never reaches an assertion.** `tests/test_affine2.py` imports `large_values.max_of`, removed in "Remove redundant code" (Oct 2024) along with the affine max machinery, and `test_all.py` imports that module first. I rebuilt the same edge case against what survived — `Affine2`/`Piecewise.min_with` — with a value check against the naive minimum, so it still tests something.

**`lv_zlv_to_zd` crashes part-way through.** #194 made `try_union` raise on an input with extreme rays. But `Region._as_disjoint_union_poly` uses `try_union` as a merge attempt and relies on the documented `None` return to keep the pieces separate, so the raise aborts the caller instead of degrading. Returning `None` there restores the pipeline and still never produces a wrong envelope. That same raise also aborted `run_union_test`, which calls `try_union` on an unbounded pair and drops the result.

Evidence, on python 3.13 with `pycddlib<3`:

- before: `python tests/test_all.py` stops at the `test_affine2` import; after: reaches "All test cases passed."
- before, on a clean checkout of main:

```
hs = Hypothesis_Set()
hs.add_hypothesis(lv.large_value_estimate_L2)
hs.add_hypotheses(literature.list_hypotheses(hypothesis_type="Zeta large value estimate"))
zd.lv_zlv_to_zd(hs, Interval(frac(1,2), 1), tau0=frac(3))
```
raises `ValueError: Polytope.try_union only supports finite polytopes`; with this branch it returns `A(x) \leq 7/6 - x/3 on [1/2,1)`.