### PR TITLE
Build the trivial zeta large value estimate as a Region

### DIFF
--- a/blueprint/src/python/zeta_large_values.py
+++ b/blueprint/src/python/zeta_large_values.py
@@ -13,21 +13,25 @@ from region import Region, Region_Type
 
 
 # Returns the trivial zeta large value estimates:
-# LV_zeta(s, t) \leq t for 1/2 \leq \s \leq 1, t \geq 0
+# LV_zeta(s, t) \leq t for 1/2 \leq \s \leq 1, t \geq 2
 def get_trivial_zlv():
-    # Trivial estimate
-    domain = Polytope(
-        [
-            [-frac(1, 2), 1, 0],  # \sigma > 1/2
-            [1, -1, 0],  # \sigma <= 1
-            [-2, 0, 1],  # \tau >= 2
-            [Constants.TAU_UPPER_LIMIT, 0, -1],  # \tau <= some large number
-        ]
+    # Trivial estimate, as a region of feasible (\sigma, \tau, \rho)
+    region = Region.from_polytope(
+        Polytope(
+            [
+                [0, 0, 1, -1],          # \rho <= \tau
+                [0, 0, 0, 1],           # \rho >= 0
+                [-frac(1, 2), 1, 0, 0], # \sigma > 1/2
+                [1, -1, 0, 0],          # \sigma <= 1
+                [-2, 0, 1, 0],          # \tau >= 2
+                [Constants.TAU_UPPER_LIMIT, 0, -1, 0],  # \tau <= some large number
+            ]
+        )
     )
     trivial = Hypothesis(
         "Trivial zeta large value estimate",
         "Zeta large value estimate",
-        lv.Large_Value_Estimate(Piecewise([Affine2([0, 0, 1], domain)])),
+        lv.Large_Value_Estimate(region, repr="ρ <= τ"),
         "Trivial",
         Reference.trivial(),
     )


### PR DESCRIPTION
`zeta_large_values.get_trivial_zlv()` raises on every call:

```
>>> import zeta_large_values as zlv; zlv.get_trivial_zlv()
ValueError: Parameter region must be of type Region
```

`Large_Value_Estimate` has taken a `Region` since the large value code moved off `Piecewise`, but this one constructor still passes a `Piecewise([Affine2([0,0,1], domain)])`. It is called from `zero_density_estimates_examples` and is the function `\code{}`-linked from the trivial bound in the zeta large values chapter, so it fails in the two places it is used from.

Rewritten as the (σ, τ, ρ) region ρ ≤ τ, in the same shape as the regions `beta_to_zlv` builds. I also corrected the header comment: the domain is τ ≥ 2, which is the convention `lv_to_zlv` states for zeta large values, not the τ ≥ 0 the comment claimed.

After the change the hypothesis prints as `ρ <= τ`, and membership checks come out right: (σ,τ,ρ) = (3/4, 3, 3) is in the region, (3/4, 3, 7/2) and (3/4, 1, 1/2) are not. Ran `python tests/test_all.py` too — no change there, the suite does not currently cover this file.