### PR TITLE
Add the Hardy--Littlewood bound mu(1/2) <= 1/6 to the literature

### DIFF
--- a/blueprint/src/python/literature.py
+++ b/blueprint/src/python/literature.py
@@ -617,6 +617,9 @@ def add_literature_bounds_mu():
     literature.add_hypotheses(
         [
             # Bounds on the critical line
+            literature_bound_mu(
+                frac(1, 2), frac(1, 6), rm.get("hardy_littlewood_1923")
+            ),
             literature_bound_mu(frac(1, 2), frac(193, 988), rm.get("walfisz_1924")),
             literature_bound_mu(
                 frac(1, 2), frac(27, 164), rm.get("titchmarsh_van_1931")


### PR DESCRIPTION
The zeta growth chapter opens its μ(1/2) table with Hardy--Littlewood (1923), μ(1/2) ≤ 1/6, from the exponent pair (1/6, 2/3). The Python `literature` set has no such hypothesis: the critical-line list starts at Walfisz (1924), and both generated sequences (van der Corput and Hardy--Littlewood) start at n = 4, one term past the σ = 1/2 member.

Everything that asks for that bound is broken as a result:

- `literature.add_bounds_mu_classic` adds `None` to the hypothesis set;
- `derived.prove_hardy_littlewood_mu_bound` and `examples.mu_bound_examples` both raise `AttributeError: 'NoneType' object has no attribute 'desc'`.

One entry, citing `hardy_littlewood_1923` which is already in references.bib.

After it, `derived.prove_hardy_littlewood_mu_bound()` runs and reproves the bound the way the blueprint describes:

```
We will reprove Hardy--Littlewood bound on \mu(1/2) (\mu(1/2) \leq 1/6).
We have Derived exponent pair (1/2, 1/2) ... van der Corput B transform.
This implies Derived exponent pair (1/6, 2/3) ... van der Corput A transform.
This implies Derived bound on \mu(1/2): \mu(1/2) \leq 1/6.
```

`tests/test_exppair.py`, `tests/test_ep_to_zd.py` and `tests/test_region.py` still pass with the extra hypothesis in the set. (`tests/test_all.py` as a whole does not run on main; that is #200.)