### PR TITLE
Call lver_to_energy_bound with the signature it has

### DIFF
--- a/blueprint/src/python/derived.py
+++ b/blueprint/src/python/derived.py
@@ -979,33 +979,12 @@ def prove_heath_brown_energy_estimate():
     hypotheses.add_hypothesis(literature.find_hypothesis(keywords="Heath-Brown large value energy region 2b"))
     hypotheses.add_hypotheses(ad.lv_to_lver(hypotheses, zeta=False))
 
-    # tau_0 as an affine function
+    # tau_0 as an affine function.  lver_to_energy_bound builds the
+    # tau0 <= tau <= 2 tau0 and 2 <= tau <= tau0 domains itself.
     tau0 = Affine(0, 2, Interval(frac(1,2), frac(3,4)))
-    LVER_domain = Region.from_polytope(
-            Polytope([
-                [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-                [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-                [-tau0.c, -tau0.m, 1],       # tau >= tau0 = m sigma + c
-                [2 * tau0.c, 2 * tau0.m, -1] # tau <= 2 tau0 = 2 m sigma + 2 c
-            ])
-        )
-
-    # Compute the feasible region for LV*(s, t) as a 3-dimensional polytope
-    LV_star_hyp = ad.compute_LV_star(hypotheses, LVER_domain, zeta=False, debug=False)
-
-    # domain representing 2 <= tau <= tau0
-    LVER_zeta_domain = Region.from_polytope(
-            Polytope([
-                [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-                [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-                [-2, 0, 1],                     # tau0 >= 2
-                [tau0.c, tau0.m, -1],           # tau <= tau0 = m sigma + c
-            ])
-        )
-    # Compute the feasible region for LV_{\zeta}*(s, t) as a 3-dimensional polytope
-    LVZ_star_hyp = ad.compute_LV_star(hypotheses, LVER_zeta_domain, zeta=True, debug=False)
-    ze.lver_to_energy_bound(LV_star_hyp, LVZ_star_hyp, tau0.domain)
-
+    hs = ze.lver_to_energy_bound(hypotheses, tau0, debug=False)
+    for h in hs:
+        print(h.data)
 
     # Part 2: \sigma \in [3/4, 25/28] ----------------------------------------------------------
 
@@ -1025,32 +1004,10 @@ def prove_heath_brown_energy_estimate():
 
     # tau_0 as an affine function
     tau0 = Affine(4, -1, Interval(frac(3,4), frac(25,28)))
-
-    LVER_domain = Region.from_polytope(
-            Polytope([
-                [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-                [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-                [-tau0.c, -tau0.m, 1],       # tau >= tau0 = m sigma + c
-                [2 * tau0.c, 2 * tau0.m, -1] # tau <= 2 tau0 = 2 m sigma + 2 c
-            ])
-        )
-
-    # Compute the feasible region for LV*(s, t) as a 3-dimensional
-    # polytope for a range of sigma
-    LV_star_hyp = ad.compute_LV_star(hypotheses, LVER_domain, zeta=False, debug=False)
-
-    # domain representing 2 <= tau <= tau0
-    LVER_zeta_domain = Region.from_polytope(
-            Polytope([
-                [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-                [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-                [-2, 0, 1],                     # tau0 >= 2
-                [tau0.c, tau0.m, -1],           # tau <= tau0 = m sigma + c
-            ])
-        )
-    # Compute the feasible region for LV_{\zeta}*(s, t) as a 3-dimensional polytope
-    LVZ_star_hyp = ad.compute_LV_star(hypotheses, LVER_zeta_domain, zeta=True, debug=False)
-    ze.lver_to_energy_bound(LV_star_hyp, LVZ_star_hyp, tau0.domain)
+    hs = ze.lver_to_energy_bound(hypotheses, tau0, debug=False)
+    for h in hs:
+        print(h.data)
+    return hs
 
 def prove_improved_heath_brown_energy_estimate():
 

--- a/blueprint/src/python/derived.py
+++ b/blueprint/src/python/derived.py
@@ -1011,10 +1011,8 @@ def prove_heath_brown_energy_estimate():
 
 def prove_improved_heath_brown_energy_estimate():
 
-    # tau_0 as a piecewise affine function
-    tau0s = [
-        Affine(8, -4, Interval(frac(3,4), frac(4,5)))
-    ]
+    # tau_0 as an affine function
+    tau0 = Affine(8, -4, Interval(frac(3,4), frac(4,5)))
 
     hypotheses = Hypothesis_Set()
 
@@ -1022,35 +1020,6 @@ def prove_improved_heath_brown_energy_estimate():
        hypotheses.add_hypothesis(ad.get_raise_to_power_hypothesis(k))
 
     # Add classical and literature Large value estimates
-    hypotheses.add_hypothesis(literature.find_hypothesis(keywords="Huxley large value estimate"))
-    hypotheses.add_hypothesis(literature.find_hypothesis(keywords="Heath-Brown large value energy region 2a"))
-
-    # Convert all large value estimates -> large value energy region
-    hypotheses.add_hypotheses(ad.lv_to_lver(hypotheses, zeta=False))
-
-    # Convert tau_0 into a Region of (sigma, tau)
-    # domain representing tau0 <= tau <= 2tau0
-    LVER_domain = Region.disjoint_union([
-        Region.from_polytope(
-            Polytope([
-                [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-                [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-                [-tau0.c, -tau0.m, 1],       # tau >= tau0 = m sigma + c
-                [2 * tau0.c, 2 * tau0.m, -1] # tau <= 2 tau0 = 2 m sigma + 2 c
-            ])
-        )
-        for tau0 in tau0s
-    ])
-    # Compute the feasible region for LV*(s, t) as a 3-dimensional
-    # polytope for a range of sigma
-    LV_star_hyp = ad.compute_LV_star(hypotheses, LVER_domain, zeta=False)
-
-    # New set of hypothesis for the zeta LVER computation
-    hypotheses = Hypothesis_Set()
-
-    for k in range(2, 3):
-        hypotheses.add_hypothesis(ad.get_raise_to_power_hypothesis(k))
-
     hypotheses.add_hypothesis(literature.find_hypothesis(keywords="Huxley large value estimate"))
     hypotheses.add_hypothesis(literature.find_hypothesis(hypothesis_type="Zeta large value estimate"))
     hypotheses.add_hypothesis(literature.find_hypothesis(keywords="Heath-Brown large value energy region 2a"))
@@ -1060,21 +1029,10 @@ def prove_improved_heath_brown_energy_estimate():
     # Convert all zeta large value estimates -> zeta large value energy region
     hypotheses.add_hypotheses(ad.lv_to_lver(hypotheses, zeta=True))
 
-    # domain representing 2 <= tau <= tau0
-    LVER_zeta_domain = Region.disjoint_union([
-        Region.from_polytope(
-            Polytope([
-                [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-                [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-                [-2, 0, 1],                     # tau0 >= 2
-                [tau0.c, tau0.m, -1],           # tau <= tau0 = m sigma + c
-            ])
-        )
-        for tau0 in tau0s
-    ])
-    # Compute the feasible region for LV_{\zeta}*(s, t) as a 3-dimensional polytope
-    LVZ_star_hyp = ad.compute_LV_star(hypotheses, LVER_zeta_domain, zeta=True)
-    bounds = ze.lver_to_energy_bound(LV_star_hyp, LVZ_star_hyp, Interval(frac(1,2), 1))
+    hs = ze.lver_to_energy_bound(hypotheses, tau0)
+    for h in hs:
+        print(h.data)
+    return hs
 
 def prove_zero_density_energy_2():
     hypotheses = Hypothesis_Set()

--- a/blueprint/src/python/examples.py
+++ b/blueprint/src/python/examples.py
@@ -498,37 +498,13 @@ def zero_density_energy_examples():
     # Convert all zeta large value estimates -> zeta large value energy region
     hypotheses.add_hypotheses(ad.lv_to_lver(hypotheses, zeta=True))
 
-    # tau_0 as a piecewise affine function
+    # tau_0 as an affine function.  lver_to_energy_bound computes the
+    # LV* and LV_zeta* regions over the tau0 <= tau <= 2 tau0 and
+    # 2 <= tau <= tau0 domains itself.
     tau0 = Affine(0, 5, Interval(frac(3,4), 1))
-    sigma_interval = tau0.domain
-
-    # domain representing tau0 <= tau <= 2 tau0
-    LVER_domain = Region.from_polytope(
-        Polytope([
-            [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-            [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-            [-tau0.c, -tau0.m, 1],       # tau >= tau0 = m sigma + c
-            [2 * tau0.c, 2 * tau0.m, -1] # tau <= 2 tau0 = 2 m sigma + 2 c
-        ])
-    )
-
-    # Compute the feasible region for LV*(s, t) as a 3-dimensional
-    # polytope for a range of sigma
-    LV_star_hyp = ad.compute_LV_star(hypotheses, LVER_domain, zeta=False)
-
-    # domain representing 2 <= tau <= tau0
-    LVER_zeta_domain = Region.from_polytope(
-        Polytope([
-            [-tau0.domain.x0, 1, 0],     # sigma >= sigma_interval.x0
-            [tau0.domain.x1, -1, 0],     # sigma <= sigma_interval.x1
-            [-2, 0, 1],                  # tau0 >= 2
-            [tau0.c, tau0.m, -1],        # tau <= tau0 = m sigma + c
-        ])
-    )
-
-    # Compute the feasible region for LV_{\zeta}*(s, t) as a 3-dimensional polytope
-    LVZ_star_hyp = ad.compute_LV_star(hypotheses, LVER_zeta_domain, zeta=True)
-    bounds = ze.lver_to_energy_bound(LV_star_hyp, LVZ_star_hyp, sigma_interval)
+    bounds = ze.lver_to_energy_bound(hypotheses, tau0)
+    for b in bounds:
+        print(b.data)
 
 # example using Lemma 6.7
 def beta_to_mu_example():


### PR DESCRIPTION
`lver_to_energy_bound(hypotheses, tau0)` builds the `tau0 <= tau <= 2 tau0` and `2 <= tau <= tau0` domains itself, but three call sites still pass the older `(LV*, LV_zeta*, sigma_interval)` triple and raise `ValueError: Parameter hypotheses must be of type Hypothesis_Set.` on the first line they reach. So `derived.prove_heath_brown_energy_estimate`, `derived.prove_improved_heath_brown_energy_estimate` and `examples.zero_density_energy_examples` cannot run at all, and the first two are the `\derived \code{}` links for two theorems in the zero density energy chapter.

Ported to the current API, dropping the domain/`compute_LV_star` blocks the callee now does itself, and printing the bounds as the `prove_zero_density_energy_*` functions do.

`prove_improved_heath_brown_energy_estimate` needed a judgement call: it built *two* hypothesis sets, one for LV* and one for LV_zeta*, which the current API cannot express. I merged them (k = 2..4, Huxley, Heath-Brown region 2a, the zeta large value estimate, both lver conversions). It reproduces the theorem the blueprint attaches to it, crossover point included:

```
A*(x) <= (18 - 19x)/(2(3x - 1)(1 - x))   on [3/4, sqrt(13889)/328 + 143/328)
A*(x) <= 4(10 - 9x)/(5(4x - 1)(1 - x))   on [sqrt(13889)/328 + 143/328, 4/5)
```

which is Theorem `imp-hb-energy-bound`. That function also passed sigma in [1/2, 1] while its tau0 was only defined on [3/4, 4/5]; the interval now comes from tau0.

`prove_heath_brown_energy_estimate` likewise reproduces `hb-energy-bound`:

```
A*(x) <= (10 - 11x)/((2 - x)(1 - x))     on [1/2, 2/3)
A*(x) <= (18 - 19x)/(2(2 - x)(1 - x))    on [2/3, 3/4)
```

and then the two improved branches above, ending at 12/(4x - 1) on [5/6, 25/28) — matching the theorem's third branch.