### PR TITLE
Raise TypeError instead of a bare string for Hypothesis_Set checks

### DIFF
--- a/blueprint/src/python/bound_beta.py
+++ b/blueprint/src/python/bound_beta.py
@@ -147,7 +147,7 @@ def apply_reflection_beta(bounds: list[Hypothesis]) -> list[Hypothesis]:
 #   - a list of Hypothesis objects, each representing a derived beta bound
 def exponent_pairs_to_beta_bounds(hypothesis_set):
     if not isinstance(hypothesis_set, Hypothesis_Set):
-        raise "hypothesis_set must be of type Hypothesis_Set"
+        raise TypeError("hypothesis_set must be of type Hypothesis_Set")
 
     hypotheses = []
     ephs = hypothesis_set.list_hypotheses(hypothesis_type="Exponent pair")

--- a/blueprint/src/python/exponent_pair.py
+++ b/blueprint/src/python/exponent_pair.py
@@ -175,7 +175,7 @@ def beta_bounds_to_exponent_pairs(
     """
 
     if not isinstance(hypothesis_set, Hypothesis_Set):
-        raise "hypothesis_set must be of type Hypothesis_Set"
+        raise TypeError("hypothesis_set must be of type Hypothesis_Set")
 
     # Compute the best bound on beta - (imported bound_beta.py method)
     beta_bound = compute_best_beta_bounds(hypothesis_set)


### PR DESCRIPTION
## Summary
- `bound_beta.py` and `exponent_pair.py` used `raise "hypothesis_set must be of type Hypothesis_Set"`.
- In Python 3 that is itself a `TypeError` and drops the intended message.
- Raise `TypeError(...)` so validation failures are intelligible.

## Test plan
- [x] Confirmed both sites used bare-string raise on upstream main
- [x] `TypeError("...")` compiles as a valid raise