### PR TITLE
Make Hypothesis.proof_depth work on literature facts

### DIFF
--- a/blueprint/src/python/hypotheses.py
+++ b/blueprint/src/python/hypotheses.py
@@ -101,11 +101,13 @@ class Hypothesis:
                 return True
             if self.reference.label == "Conjectured":
                 return False
-            if (
-                self.reference.year() != "Unknown date"
-                and self.reference.year() <= year
-            ):
-                return True
+            y = self.reference.year()
+            if y == "Unknown date":
+                return False
+            try:
+                return int(y) <= int(year)
+            except (TypeError, ValueError):
+                return False
         return False
 
     def proof_complexity(self) -> int:
@@ -132,6 +134,8 @@ class Hypothesis:
             The maximum depth of the tree that represents the dependency
             structure of this hypothesis.
         """
+        if not self.dependencies:
+            return 1
         return 1 + max(d.proof_depth() for d in self.dependencies)
 
     def proof_date(self) -> int:
@@ -145,9 +149,12 @@ class Hypothesis:
         int
             The year of the latest dependency of this hypothesis, or -1 if unknown.
         """
-        year = self.reference.year()
-        if year == "Unknown date":
-            year = -1
+        def as_year(y):
+            if y == "Unknown date" or y is None:
+                return -1
+            return int(y)
+
+        year = as_year(self.reference.year())
         return max([year] + [h.proof_date() for h in self.dependencies])
 
 
@@ -173,7 +180,7 @@ class Hypothesis_Set:
     # Shallow copy, the hypothesis objects are not cloned
     def __copy__(self):
         copy = Hypothesis_Set(self.hypotheses)
-        copy.data = self.data
+        copy.data = dict(self.data)
         copy.data_valid = self.data_valid
         return copy
 
@@ -211,7 +218,7 @@ class Hypothesis_Set:
             self.add_hypothesis(new_hypotheses, invalidate_data)
         elif isinstance(new_hypotheses, Hypothesis_Set):
             self.add_hypotheses(new_hypotheses.hypotheses, invalidate_data)
-        elif isinstance(new_hypotheses, list):
+        elif isinstance(new_hypotheses, list) or isinstance(new_hypotheses, tuple):
             self.add_hypotheses(set(new_hypotheses), invalidate_data)
         else:
             self.hypotheses.update(new_hypotheses)
@@ -265,5 +272,4 @@ class Hypothesis_Set:
                         ):
                             if year == "Any" or h.reference.year() == year:
                                 return h
-        print("ERROR: No matching hypothesis found")
         return None

--- a/blueprint/src/python/hypotheses.py
+++ b/blueprint/src/python/hypotheses.py
@@ -187,9 +187,6 @@ class Hypothesis_Set:
     def __iter__(self):
         return self.hypotheses.__iter__()
 
-    def __next__(self):
-        return self.hypotheses.__next__()
-
     def __len__(self):
         return len(self.hypotheses)
 

--- a/blueprint/src/python/tests/test_all.py
+++ b/blueprint/src/python/tests/test_all.py
@@ -40,4 +40,8 @@ import test_ep_to_zd
 
 print("All ep_to_zd regression test cases passed.")
 
+import test_hypothesis
+
+print("All Hypothesis test cases passed.")
+
 print("All test cases passed.")

--- a/blueprint/src/python/tests/test_hypothesis.py
+++ b/blueprint/src/python/tests/test_hypothesis.py
@@ -80,3 +80,13 @@ test_add_hypotheses_accepts_a_tuple()
 test_find_hypothesis_returns_none_quietly()
 test_is_match_accepts_year_as_string()
 test_hypothesis_set_iterates()
+
+
+def test_list_hypotheses_compares_years_as_ints():
+    h = Hypothesis("x", "Upper bound on mu", type("D", (), {"__repr__": lambda self: "d"})(), "p", Reference.make("X", 1999))
+    hs = Hypothesis_Set([h])
+    assert hs.list_hypotheses(year="1999") == [h]
+    assert hs.list_hypotheses(year="1998") == []
+
+
+test_list_hypotheses_compares_years_as_ints()

--- a/blueprint/src/python/tests/test_hypothesis.py
+++ b/blueprint/src/python/tests/test_hypothesis.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from copy import copy
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path[:0] = [_TESTS_DIR, os.path.dirname(_TESTS_DIR)]
+
+from hypotheses import Hypothesis, Hypothesis_Set
+from reference import Reference
+
+
+def _hyp(name="leaf"):
+    return Hypothesis(name, "Upper bound on mu", type("D", (), {"__repr__": lambda self: "d"})(), "leaf", Reference.classical())
+
+
+def test_proof_depth_on_a_leaf():
+    # max() of an empty generator used to raise here.
+    h = _hyp()
+    assert h.proof_depth() == 1
+    assert h.proof_complexity() == 1
+    assert h.proof_date() == -1
+
+
+def test_proof_depth_on_a_tree():
+    leaf = _hyp("a")
+    mid = Hypothesis("mid", "Upper bound on mu", type("D", (), {"__repr__": lambda self: "d"})(), "mid", Reference.derived(1990))
+    mid.add_dependency(leaf)
+    root = Hypothesis("root", "Upper bound on mu", type("D", (), {"__repr__": lambda self: "d"})(), "root", Reference.derived(2001))
+    root.add_dependency(mid)
+    assert mid.proof_depth() == 2
+    assert root.proof_depth() == 3
+    assert root.proof_complexity() == 3
+    assert root.proof_date() == 2001
+
+
+def test_hypothesis_set_copy_does_not_share_cached_data():
+    hs = Hypothesis_Set()
+    hs.data["hull"] = [1]
+    other = copy(hs)
+    other.data["hull"] = [2]
+    assert hs.data["hull"] == [1]
+
+
+def test_add_hypotheses_accepts_a_tuple():
+    a = _hyp("a")
+    b = _hyp("b")
+    hs = Hypothesis_Set()
+    hs.add_hypotheses((a, b))
+    assert len(hs) == 2
+
+
+def test_find_hypothesis_returns_none_quietly():
+    hs = Hypothesis_Set()
+    assert hs.find_hypothesis(name="missing") is None
+
+
+def test_is_match_accepts_year_as_string():
+    h = Hypothesis("x", "Upper bound on mu", type("D", (), {"__repr__": lambda self: "d"})(), "p", Reference.make("X", 1999))
+    assert h.is_match(year="2000")
+    assert not h.is_match(year="1990")
+
+
+test_proof_depth_on_a_leaf()
+test_proof_depth_on_a_tree()
+test_hypothesis_set_copy_does_not_share_cached_data()
+test_add_hypotheses_accepts_a_tuple()
+test_find_hypothesis_returns_none_quietly()
+test_is_match_accepts_year_as_string()

--- a/blueprint/src/python/tests/test_hypothesis.py
+++ b/blueprint/src/python/tests/test_hypothesis.py
@@ -60,9 +60,16 @@ def test_is_match_accepts_year_as_string():
     assert not h.is_match(year="1990")
 
 
+def test_hypothesis_set_iterates():
+    a = _hyp("a")
+    hs = Hypothesis_Set([a])
+    assert list(hs) == [a]
+
+
 test_proof_depth_on_a_leaf()
 test_proof_depth_on_a_tree()
 test_hypothesis_set_copy_does_not_share_cached_data()
 test_add_hypotheses_accepts_a_tuple()
 test_find_hypothesis_returns_none_quietly()
 test_is_match_accepts_year_as_string()
+test_hypothesis_set_iterates()

--- a/blueprint/src/python/tests/test_hypothesis.py
+++ b/blueprint/src/python/tests/test_hypothesis.py
@@ -64,6 +64,13 @@ def test_hypothesis_set_iterates():
     a = _hyp("a")
     hs = Hypothesis_Set([a])
     assert list(hs) == [a]
+    # a second pass must work
+    assert list(hs) == [a]
+    try:
+        next(hs)
+        raise AssertionError("Hypothesis_Set is not an iterator")
+    except TypeError:
+        pass
 
 
 test_proof_depth_on_a_leaf()


### PR DESCRIPTION
## Summary
- `proof_depth` used `max()` over dependencies, which raises on a leaf. Literature hypotheses have an empty tree.
- `copy` of a `Hypothesis_Set` no longer shares the cached `data` dict.
- `is_match` compares years as integers so a string cutoff does not TypeError.
- Dropped a broken `__next__` on the set wrapper.
- `find_hypothesis` returns `None` without printing ERROR.
- Accept tuples in `add_hypotheses`.

## Test plan
- [x] `python3.11 tests/test_hypothesis.py` (no matplotlib needed)
