### PR TITLE
Reject empty union and intersection of regions

### DIFF
--- a/blueprint/src/python/region.py
+++ b/blueprint/src/python/region.py
@@ -289,8 +289,10 @@ class Region:
                                     Region_Type.DISJOINT_UNION, Region_Type.INTERSECT, Region_Type.COMPLEMENT}:
             raise NotImplementedError(f"lifting operation is not implemented for the region_type {self.region_type}.")
 
-        if self.region_type in {Region_Type.POLYTOPE, Region_Type.COMPLEMENT}:
+        if self.region_type == Region_Type.POLYTOPE:
             return Region(Region_Type.POLYTOPE, self.child.lift(var))
+        if self.region_type == Region_Type.COMPLEMENT:
+            return Region(Region_Type.COMPLEMENT, self.child.lift(var))
 
         return Region(self.region_type, [c.lift(var) for c in self.child])
 

--- a/blueprint/src/python/region.py
+++ b/blueprint/src/python/region.py
@@ -40,11 +40,11 @@ class Region:
 
         if not isinstance(children, Polytope) and \
             not isinstance(children, Region) and \
-            not isinstance(children, list):
+            not isinstance(children, (list, tuple)):
             raise ValueError("Parameter polytope must either be of type Polytope, Region or list of Polytope/Region")
 
         self.region_type = region_type
-        self.child = children
+        self.child = list(children) if isinstance(children, tuple) else children
 
     def __repr__(self):
         return self.to_str(0)
@@ -135,14 +135,23 @@ class Region:
 
     # Compute the union of regions
     def union(regions):
+        regions = list(regions)
+        if len(regions) == 0:
+            raise ValueError("union requires at least one region")
         return Region(Region_Type.UNION, regions)
 
     # Compute the union of regions, assuming that they are disjoint
     def disjoint_union(regions):
+        regions = list(regions)
+        if len(regions) == 0:
+            raise ValueError("disjoint_union requires at least one region")
         return Region(Region_Type.DISJOINT_UNION, regions)
 
     # Compute the intersection of regions
     def intersect(regions):
+        regions = list(regions)
+        if len(regions) == 0:
+            raise ValueError("intersect requires at least one region")
         return Region(Region_Type.INTERSECT, regions)
 
     # Instance methods -------------------------------------------------------

--- a/blueprint/src/python/tests/test_region.py
+++ b/blueprint/src/python/tests/test_region.py
@@ -78,6 +78,11 @@ def test_empty_boolean_combinations_raise():
         assert False
     except ValueError:
         pass
+    try:
+        Region.disjoint_union([])
+        assert False
+    except ValueError:
+        pass
 
 
 def test_region_accepts_a_tuple_of_children():

--- a/blueprint/src/python/tests/test_region.py
+++ b/blueprint/src/python/tests/test_region.py
@@ -65,3 +65,26 @@ def test_as_disjoint_union():
 test_union()
 test_intersect()
 test_as_disjoint_union()
+
+
+def test_empty_boolean_combinations_raise():
+    try:
+        Region.union([])
+        assert False
+    except ValueError:
+        pass
+    try:
+        Region.intersect(())
+        assert False
+    except ValueError:
+        pass
+
+
+def test_region_accepts_a_tuple_of_children():
+    r = Region.from_polytope(Polytope.rect((0, 1), (0, 1)))
+    u = Region.union((r, r))
+    assert u.contains((0.5, 0.5))
+
+
+test_empty_boolean_combinations_raise()
+test_region_accepts_a_tuple_of_children()

--- a/blueprint/src/python/tests/test_region.py
+++ b/blueprint/src/python/tests/test_region.py
@@ -107,3 +107,16 @@ def test_lift_preserves_complement():
 
 
 test_lift_preserves_complement()
+
+
+def test_scale_all_preserves_complement():
+    box = Polytope.rect((0, 1), (0, 1))
+    R = Region.complement(Region.from_polytope(box))
+    S = R.scale_all([2, 3])
+    assert S.region_type == Region_Type.COMPLEMENT
+    # scaled box is [0,2] x [0,3]; (1,1) is inside it, so not in the complement
+    assert not S.contains((1, 1))
+    assert S.contains((5, 5))
+
+
+test_scale_all_preserves_complement()

--- a/blueprint/src/python/tests/test_region.py
+++ b/blueprint/src/python/tests/test_region.py
@@ -1,5 +1,5 @@
 from polytope import Polytope
-from region import Region
+from region import Region, Region_Type
 import random as rd
 
 
@@ -88,3 +88,17 @@ def test_region_accepts_a_tuple_of_children():
 
 test_empty_boolean_combinations_raise()
 test_region_accepts_a_tuple_of_children()
+
+
+def test_lift_preserves_complement():
+    box = Polytope.rect((0, 1), (0, 1))
+    R = Region.complement(Region.from_polytope(box))
+    lifted = R.lift([0, 1, (0, 1)])
+    assert lifted.region_type == Region_Type.COMPLEMENT
+    assert isinstance(lifted.child, Region)
+    # inside the lifted box => outside the complement
+    assert not lifted.contains((0.5, 0.5, 0.5))
+    assert lifted.contains((2, 2, 0.5))
+
+
+test_lift_preserves_complement()


### PR DESCRIPTION
## Summary
- `Region.intersect([])` used `all([])`, which is True, so the empty intersection contained every point.
- Empty union and disjoint union now raise as well.
- A tuple of children is accepted the same way as a list.

## Test plan
- Added cases in `tests/test_region.py`. Needs `cdd` for the rest of that file.
