### PR TITLE
Reject bad Interval.parse strings and non-interval equality

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -52,6 +52,8 @@ class Interval:
         return f"{lower_bracket}{self.x0},{self.x1}{upper_bracket}"
 
     def __eq__(self, other):
+        if not isinstance(other, Interval):
+            return NotImplemented
         # All empty intervals are considered equal
         if self.is_empty() and other.is_empty():
             return True
@@ -64,8 +66,15 @@ class Interval:
 
     # -------------------------------------------------------------------------
     # Public static functions
+    @staticmethod
     def parse(s):
+        if not isinstance(s, str) or len(s) < 5:
+            raise ValueError("Interval string must look like [a, b] or (a, b)")
+        if s[0] not in "[(" or s[-1] not in "])":
+            raise ValueError(f"Interval string {s!r} must start with [ or ( and end with ] or )")
         inner = s[1:-1].split(",")
+        if len(inner) != 2:
+            raise ValueError(f"Interval string {s!r} must contain exactly two endpoints")
         return Interval(
             frac(inner[0].strip()), frac(inner[1].strip()), s[0] == "[", s[-1] == "]"
         )

--- a/blueprint/src/python/tests/test_interval.py
+++ b/blueprint/src/python/tests/test_interval.py
@@ -11,4 +11,19 @@ def run_all():
     assert i1.intersect(Interval(2, 3, False, False)).is_empty()
     assert not i1.intersect(Interval(-1, 0, False, True)).is_empty()
 
+    parsed = Interval.parse("[0, 2)")
+    assert parsed == Interval(0, 2, True, False)
+    try:
+        Interval.parse("0, 2")
+        raise AssertionError("parse should reject a string without brackets")
+    except ValueError:
+        pass
+    try:
+        Interval.parse("[0, 1, 2]")
+        raise AssertionError("parse should reject three endpoints")
+    except ValueError:
+        pass
+    assert Interval(0, 2) != "[0, 2)"
+    assert not (Interval(0, 0, False, False) == "empty")
+
 run_all()


### PR DESCRIPTION
## Summary
- `Interval.parse` sliced `s[1:-1]` with no check, so `'0, 2'` and `'[0, 1, 2]'` were treated as intervals.
- It now requires `[a, b]` / `(a, b)` shape with exactly two endpoints.
- `__eq__` returns `NotImplemented` for a non-`Interval`, instead of calling `is_empty` on a string.

## Test plan
- [ ] `PYTHONPATH=blueprint/src/python python tests/test_interval.py`
- [ ] `Interval.parse('[0, 2)')` still matches the constructor
