### PR TITLE
Handle unbounded containment objectives instead of accepting their placeholder values

### DIFF
--- a/blueprint/src/python/polytope.py
+++ b/blueprint/src/python/polytope.py
@@ -659,6 +659,11 @@ class Polytope:
         if not isinstance(other, Polytope):
             raise ValueError("Parameter other must be of type Polytope")
 
+        if self.dimension() != other.dimension():
+            raise ValueError("Polytopes must have the same dimension")
+        if self.is_empty(include_boundary=True):
+            return True
+
         # Returns the H rep of a polytope as inequalities only (representing
         # equality constraints via two-sided constraints)
         def as_ineq(mat):
@@ -684,6 +689,12 @@ class Polytope:
             mat.obj_func = ab
             lp = cdd.LinProg(mat)
             lp.solve()
+            if lp.status in (cdd.LPStatusType.DUAL_INCONSISTENT,
+                             cdd.LPStatusType.STRUC_DUAL_INCONSISTENT,
+                             cdd.LPStatusType.UNBOUNDED):
+                return False  # The constraint is unbounded below on self.
+            if lp.status != cdd.LPStatusType.OPTIMAL:
+                raise RuntimeError(f"Containment LP failed: {lp.status}")
             if lp.obj_value < 0:
                 return False
         return True

--- a/blueprint/src/python/tests/test_polytope.py
+++ b/blueprint/src/python/tests/test_polytope.py
@@ -426,6 +426,8 @@ def run_setminus_test():
     assert any(p.contains((3, 3)) for p in A_minus_B)
 
 def run_containment_test():
+    import test_subset_regression
+
     p1 = Polytope.rect((0, 1), (0, 1))
     p2 = Polytope.rect((0, 2), (0, 2))
     assert p1.is_subset_of(p1)

--- a/blueprint/src/python/tests/test_subset_regression.py
+++ b/blueprint/src/python/tests/test_subset_regression.py
@@ -1,0 +1,19 @@
+from polytope import Polytope
+
+def run_regressions():
+    positive = Polytope([[0, 1]])
+    negative = Polytope([[0, -1]])
+    whole = Polytope([[1, 0]])
+    assert not positive.is_subset_of(negative)
+    assert not whole.is_subset_of(positive)
+    assert positive.is_subset_of(whole)
+    assert Polytope([[0, 2]]).is_subset_of(positive)
+    assert not positive.is_subset_of(Polytope([[0, 1]], linear=True))
+    assert Polytope.rect((0, 0)).is_subset_of(positive)
+    empty = Polytope([[-1, 1], [0, -1]])
+    assert empty.is_subset_of(positive)
+    assert empty.is_subset_of(empty)
+    assert not positive.is_subset_of(empty)
+    assert Polytope.rect((0, 1)).is_subset_of(Polytope.rect((-1, 2)))
+
+run_regressions()


### PR DESCRIPTION
The half-line `x >= 0` is currently reported as a subset of `x <= 0`. The LP is unbounded below, but `is_subset_of` reads `obj_value` without checking the solver status.

Reject unbounded objectives, handle an empty source vacuously, validate ambient dimensions, and raise for unexpected solver failures instead of asserting containment. Regression cases cover opposite rays, whole space, equality constraints, empty sets, and bounded containment.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
