### PR TITLE
Compare recession and lineality generators in polytope equality

### DIFF
--- a/blueprint/src/python/polytope.py
+++ b/blueprint/src/python/polytope.py
@@ -165,14 +165,32 @@ class Polytope:
         )
 
     def __eq__(self, other):
-        if self.vertices is None:
-            self.compute_V_rep()
-        if other.vertices is None:
-            other.compute_V_rep()
-        # Construct set of vertices from V representation (as tuples which are hashable)
-        return set(tuple(v) for v in self.vertices) == set(
-            tuple(v) for v in other.vertices
-        )
+        if not isinstance(other, Polytope):
+            return NotImplemented
+        if self.dimension() != other.dimension():
+            return False
+        empty = self.is_empty(include_boundary=True)
+        other_empty = other.is_empty(include_boundary=True)
+        if empty or other_empty:
+            return empty and other_empty
+
+        def generators_satisfy(source, target):
+            generators = source.polyhedron.get_generators()
+            rows = list(generators)
+            # cdd omits the origin from homogeneous cones.
+            if not any(row[0] for row in rows):
+                rows.append((1,) + (0,) * source.dimension())
+            for j, generator in enumerate(rows):
+                for i, constraint in enumerate(target.mat):
+                    value = sum(a * b for a, b in zip(constraint, generator))
+                    if i in target.mat.lin_set or j in generators.lin_set:
+                        if value != 0:
+                            return False
+                    elif value < 0:
+                        return False
+            return True
+
+        return generators_satisfy(self, other) and generators_satisfy(other, self)
 
     # -------------------------------------------------------------------------
     # internal/private functions

--- a/blueprint/src/python/tests/test_equality_regression.py
+++ b/blueprint/src/python/tests/test_equality_regression.py
@@ -1,0 +1,19 @@
+from polytope import Polytope
+
+def run_regressions():
+    positive = Polytope([[0, 1]])
+    negative = Polytope([[0, -1]])
+    assert positive != negative
+    assert positive == Polytope([[0, 7]])
+    assert Polytope([[1, 0]]) != positive
+    assert Polytope([[1, 0]]) == Polytope([[2, 0]])
+    assert Polytope([[0, 1, 0]]) != Polytope([[0, 0, 1]])
+    assert Polytope([[0, 1, 0]]) == Polytope([[0, 3, 0]])
+    assert Polytope.rect((0, 1)) == Polytope([[0, 2], [3, -3]])
+    assert Polytope.rect((0, 0)) != Polytope.rect((0, 0), (0, 0))
+    assert positive != object()
+    empty = Polytope([[-1, 1], [0, -1]])
+    assert empty == Polytope([[-2, 1], [0, -1]])
+    assert empty != positive
+
+run_regressions()

--- a/blueprint/src/python/tests/test_polytope.py
+++ b/blueprint/src/python/tests/test_polytope.py
@@ -11,6 +11,8 @@ def get_unit_square():
     )
 
 def run_polytope_tests():
+    import test_equality_regression
+
 
     p = get_unit_square()
     assert p.polyhedron.rep_type == cdd.RepType.INEQUALITY


### PR DESCRIPTION
Opposite half-lines currently compare equal because `Polytope.__eq__` only compares vertices. Cones can have no explicit vertices in cdd's representation, and sets with identical vertices can have different recession directions.

Check mutual satisfaction of the full generator and constraint representations, including homogeneous rays, both signs of lineality directions, and the implicit origin of homogeneous cones. Handle empty sets, ambient dimensions, and unrelated Python objects explicitly. Regressions cover opposite rays, distinct halfspaces, equivalent rescaled constraints, whole spaces, and empty polytopes.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
