### PR TITLE
Preserve rays and lineality under polytope projection

### DIFF
--- a/blueprint/src/python/polytope.py
+++ b/blueprint/src/python/polytope.py
@@ -744,23 +744,32 @@ class Polytope:
         new_mat.lin_set = self.mat.lin_set # copy over the lin set
         return Polytope._from_mat(new_mat)
 
-    # Given a set of integers representing the indices of dimensions, returns a
-    # new Polytope object projected onto those dimensions.
-    #
-    # Note: this method uses the V representation of a polytope so only works
-    # for finite polytopes.
+    # Project all generators, including recession rays and lineality directions.
     def project(self, dims):
         if not isinstance(dims, set):
-            raise ValueError("Parameter dims must of type set.")
+            raise ValueError("Parameter dims must be of type set.")
+        if any(not isinstance(i, int) or i < 0 or i >= self.dimension() for i in dims):
+            raise ValueError("Projection dimensions must be valid coordinate indices")
+        if self.is_empty(include_boundary=True):
+            return None
 
-        if self.vertices is None:
-            self.compute_V_rep()
-
-        projected_verts = []
-        for v in self.vertices:
-            projected_verts.append([v[i] for i in range(len(v)) if i in dims])
-        proj = Polytope.from_V_rep(projected_verts)
-        return proj
+        generators = self.polyhedron.get_generators()
+        rows = []
+        linear = set()
+        for j, row in enumerate(generators):
+            projected = [row[0]] + [row[i + 1] for i in sorted(dims)]
+            if not any(projected):
+                continue  # A ray in the kernel contributes no direction.
+            if j in generators.lin_set:
+                linear.add(len(rows))
+            rows.append(projected)
+        if not any(row[0] for row in rows):
+            rows.append([1] + [0] * len(dims))
+        matrix = cdd.Matrix(rows, number_type="fraction")
+        matrix.rep_type = cdd.RepType.GENERATOR
+        matrix.lin_set = linear
+        inequalities = cdd.Polyhedron(matrix).get_inequalities()
+        return Polytope._from_mat(inequalities)
 
     # Given a list (var) x[0], x[1], ..., x[N - 1], with N > self.dimension(),
     # returns a polytope formed by lifting this polytope to N dimensions.

--- a/blueprint/src/python/tests/test_polytope.py
+++ b/blueprint/src/python/tests/test_polytope.py
@@ -223,6 +223,8 @@ def run_intersection_test():
     assert p1.intersect(p2).is_empty(include_boundary=True)
 
 def run_V_init_test():
+    import test_unbounded_projection_regression
+
     verts = [[0, 0], [0, 1], [1, 1], [1, 0]]
     p = Polytope.from_V_rep(verts)
     assert set(tuple(v) for v in verts) == set(tuple(v) for v in p.get_vertices())

--- a/blueprint/src/python/tests/test_unbounded_projection_regression.py
+++ b/blueprint/src/python/tests/test_unbounded_projection_regression.py
@@ -1,0 +1,24 @@
+from polytope import Polytope
+
+def run_regressions():
+    strip = Polytope([[0, 1, 0], [0, 0, 1], [1, 0, -1]])
+    ray = strip.project({0})
+    assert ray.contains([2]) and not ray.contains([-1])
+    bounded = strip.project({1})
+    assert bounded.contains([0]) and bounded.contains([1])
+    assert not bounded.contains([2])
+    whole_line = Polytope([[0, 1, 0], [1, -1, 0]]).project({1})
+    assert whole_line.contains([-100]) and whole_line.contains([100])
+    negative = Polytope([[0, -1, 0], [0, 0, 1]], linear=False).project({0})
+    assert negative.contains([-2]) and not negative.contains([1])
+    assert strip.project(set()).contains([])
+    assert Polytope([[-1, 1], [0, -1]]).project({0}) is None
+    for dims in ({-1}, {2}, {"x"}):
+        try:
+            strip.project(dims)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Invalid projection coordinate accepted")
+
+run_regressions()


### PR DESCRIPTION
Projecting `[0, infinity) × [0, 1]` onto its first coordinate currently returns only `{0}`: `project` discards every generator except vertices. Projecting onto an unbounded lineality direction is likewise truncated.

Project the full cdd generator representation, retain lineality metadata, drop directions in the projection kernel, and supply the implicit origin when required. Keep the existing `None` result for empty sets and validate coordinate indices. Tests cover rays of both signs, whole-line images, bounded images of unbounded sets, zero-coordinate projections, and invalid coordinates.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
