### PR TITLE
Intersect regions before projecting their convex components

### DIFF
--- a/blueprint/src/python/region.py
+++ b/blueprint/src/python/region.py
@@ -263,11 +263,30 @@ class Region:
             return Region(Region_Type.UNION, ps)
 
         if self.region_type == Region_Type.INTERSECT:
-            ps = [c.project(dims) for c in self.child]
-            ps = [p for p in ps if p is not None]
-            if len(ps) == 0: return None
-            if len(ps) == 1: return ps[0]
-            return Region(Region_Type.INTERSECT, ps)
+            def convex_parts(region):
+                if region.region_type == Region_Type.POLYTOPE:
+                    return [] if region.child.is_empty(True) else [region.child]
+                if region.region_type in {Region_Type.UNION, Region_Type.DISJOINT_UNION}:
+                    return [p for child in region.child for p in convex_parts(child)]
+                if region.region_type == Region_Type.INTERSECT:
+                    if not region.child:
+                        raise ValueError("Cannot infer the dimension of an empty intersection")
+                    parts = convex_parts(region.child[0])
+                    for child in region.child[1:]:
+                        intersections = [Polytope.intersection([p, q])
+                                         for p in parts for q in convex_parts(child)]
+                        parts = [p for p in intersections if not p.is_empty(True)]
+                    return parts
+                raise NotImplementedError("Projection of complements is not supported")
+
+            projected = [p.project(dims) for p in convex_parts(self)]
+            children = [Region(Region_Type.POLYTOPE, p)
+                        for p in projected if p is not None]
+            if not children:
+                return None
+            if len(children) == 1:
+                return children[0]
+            return Region(Region_Type.UNION, children)
 
         # In particular, complements are not yet supported.
         raise NotImplementedError()

--- a/blueprint/src/python/tests/test_region.py
+++ b/blueprint/src/python/tests/test_region.py
@@ -65,3 +65,5 @@ def test_as_disjoint_union():
 test_union()
 test_intersect()
 test_as_disjoint_union()
+
+import test_region_projection_regression

--- a/blueprint/src/python/tests/test_region_projection_regression.py
+++ b/blueprint/src/python/tests/test_region_projection_regression.py
@@ -1,0 +1,21 @@
+from polytope import Polytope
+from region import Region, Region_Type as T
+
+def box(x, y):
+    return Region(T.POLYTOPE, Polytope.rect(x, y))
+
+def run_regressions():
+    a = box((0, 1), (0, 1))
+    b = box((0, 1), (2, 3))
+    assert Region(T.INTERSECT, [a, b]).project({0}) is None
+    face = Region(T.INTERSECT, [a, box((0, 1), (1, 2))]).project({0})
+    assert face.contains([0]) and face.contains([1])
+    assert not face.contains([2])
+    union = Region(T.UNION, [a, b])
+    projected = Region(T.INTERSECT, [union, box((0, 2), (2, 4))]).project({0})
+    assert projected.contains([0]) and not projected.contains([2])
+    empty = Region(T.UNION, [])
+    assert Region(T.INTERSECT, [a, empty]).project({0}) is None
+    assert Region(T.INTERSECT, [Region(T.INTERSECT, [a, b]), a]).project({0}) is None
+
+run_regressions()


### PR DESCRIPTION
Two disjoint rectangles with the same horizontal extent currently have a nonempty projected intersection. Projection does not commute with intersection; projecting each child first removes the coordinates that witness their incompatibility.

Distribute intersections over convex union components in the original space, discard only actually empty components, then project the resulting polytopes. Preserve shared faces and other lower-dimensional intersections. Regressions cover disjoint rectangles, shared faces, nested unions/intersections, and an empty union child. Complements remain explicitly unsupported.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
