### PR TITLE
Keep affine envelope cells clipped and independent of their inputs

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -246,7 +246,7 @@ class Affine:
                 x = crits[i]
                 interval = Interval(x, x, True, True)
                 if domain is None or domain.contains(x):
-                    p = self if self.domain.contains(x) else None
+                    p = compare_f(self, None, interval) if self.domain.contains(x) else None
                     for f in f2:
                         if f.domain.contains(x):
                             p = compare_f(p, f, interval)
@@ -258,7 +258,7 @@ class Affine:
             # Consider the interval (crits[i], crits[i + 1])
             interval = Interval(crits[i], crits[i + 1], False, False)
             test_x = interval.midpoint()
-            p = self if self.domain.contains(test_x) else None
+            p = compare_f(self, None, interval) if self.domain.contains(test_x) else None
             for f in f2:
                 if f.domain.contains(test_x):
                     p = compare_f(p, f, interval)
@@ -278,17 +278,7 @@ class Affine:
                 p1.domain.x1 == p2.domain.x0
                 and (p1.domain.include_upper or p2.domain.include_lower)
                 and pieces[j].label == pieces[j + 1].label
-                and (
-                    (
-                        p1.domain.length() == 0
-                        and p1.at(p1.domain.x1) == p2.at(p2.domain.x0)
-                    )
-                    or (
-                        p2.domain.length() == 0
-                        and p1.at(p1.domain.x1) == p2.at(p2.domain.x0)
-                    )
-                    or (p1.function_equals(p2))
-                )
+                and p1.function_equals(p2)
             )
 
             # Extend the interval of p1 to include p2 (no need to update argmin[j])

--- a/blueprint/src/python/tests/test_affine_envelope_regression.py
+++ b/blueprint/src/python/tests/test_affine_envelope_regression.py
@@ -1,0 +1,25 @@
+from functions import Affine, Interval
+from fractions import Fraction as F
+
+def run_regressions():
+    f = Affine(1, 0, Interval(0, 4, True, True))
+    g = Affine(-1, 4, Interval(1, 3, False, True))
+    originals = [v.domain.deep_copy() for v in (f, g)]
+    for method, choose in ((f.min_with, min), (f.max_with, max)):
+        domain = Interval(F(1, 2), F(7, 2), False, True)
+        pieces = method([g], domain)
+        for x in [F(k, 4) for k in range(17)]:
+            active = [p for p in pieces if p.domain.contains(x)]
+            if not domain.contains(x):
+                assert not active
+            else:
+                assert len(active) == 1
+                values = [v.at(x) for v in (f, g) if v.domain.contains(x)]
+                assert active[0].at(x) == choose(values)
+        assert f.domain == originals[0] and g.domain == originals[1]
+        assert all(p is not f and p is not g for p in pieces)
+    only = f.min_with([], Interval(1, 2, False, False))
+    assert len(only) == 1 and only[0].domain == Interval(1, 2, False, False)
+    assert f.domain == originals[0]
+
+run_regressions()

--- a/blueprint/src/python/tests/test_interval.py
+++ b/blueprint/src/python/tests/test_interval.py
@@ -12,3 +12,5 @@ def run_all():
     assert not i1.intersect(Interval(-1, 0, False, True)).is_empty()
 
 run_all()
+
+import test_affine_envelope_regression


### PR DESCRIPTION
When only the original affine function is active on an envelope cell, `compare_with` appends that original object with its entire domain. This produces overlapping pieces, ignores requested clipping, and lets the simplification pass mutate the input domain.

Construct a fresh affine piece on every active singleton or open cell. Merge only pieces with the same affine function and label, so a singleton's coefficients cannot replace a different function on an adjacent interval. Exact-grid regressions check both minima and maxima, unique coverage, clipping, endpoint values, and unchanged inputs, including comparison against an empty list.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
