### PR TITLE
Compute rational envelopes without finite sentinels or lost boundary values

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -816,60 +816,61 @@ class RationalFunction:
             track_dependencies=True
         ) -> list:
 
-        # Start with default bound with reference index -1
-        best_bound = [(RationalFunction([default]), domain, -1)]
+        if domain.is_empty():
+            return []
+        x = RationalFunction.x
 
-        for ref1 in range(len(func_and_domains)):
-            (func1, in1) = func_and_domains[ref1]
+        def real_roots(expression):
+            expression = sympy.sympify(expression)
+            if expression.is_constant():
+                return []
+            return sympy.real_roots(expression)
 
-            new_best_bound = []
-            for (func2, in2, ref2) in best_bound:
-                solns = sympy.solve(func1.num / func1.den - func2.num / func2.den)
-                crits = set(SympyHelper.to_frac(soln) for soln in solns if soln.is_real)
-                crits.update([in1.x0, in1.x1])
-                crits = set(c for c in crits if in2.contains(c))
-                crits.update([in2.x0, in2.x1])
+        # A winner can change at a domain endpoint, an intersection, or a pole.
+        crits = {domain.x0, domain.x1}
+        for i, (func, interval) in enumerate(func_and_domains):
+            crits.update([interval.x0, interval.x1])
+            crits.update(real_roots(func.den))
+            for other, _ in func_and_domains[:i]:
+                crits.update(real_roots(func.num * other.den - other.num * func.den))
+        crits = sorted(c for c in crits if domain.x0 <= c <= domain.x1)
+        cells = []
+        for i, point in enumerate(crits):
+            if domain.contains(point):
+                cells.append(Interval(point, point, True, True))
+            if i + 1 < len(crits):
+                cells.append(Interval(point, crits[i + 1], False, False))
 
-                crits = list(crits)
-                crits.sort()
-                for i in range(1, len(crits)):
-                    inter = Interval(crits[i - 1], crits[i])
-                    mid = inter.midpoint()
-                    if not in1.contains(mid) or comparator(func2.at(mid), func1.at(mid)):
-                        new_best_bound.append((func2, inter, ref2)) # f2 is the better bound
-                    else:
-                        new_best_bound.append((func1, inter, ref1))
-
-            # Simplify
-            best_bound = []
-            i = 0
-            while i < len(new_best_bound):
-                (fi, inti, refi) = new_best_bound[i]
-                left = inti.x0
-                right = inti.x1
-
-                j = i + 1
-                while j < len(new_best_bound):
-                    (fj, intj, refj) = new_best_bound[j]
-                    #print(type(refi), type(refj))
-                    if not (fi == fj and right == intj.x0 and (not track_dependencies or refi == refj)):
-                        break
-                    right = intj.x1
-                    j += 1
-
-                best_bound.append((fi, Interval(left, right), refi))
-                i = j
+        fallback = RationalFunction([default])
+        best_bound = []
+        for cell in cells:
+            mid = cell.midpoint()
+            winner, ref = fallback, -1
+            for i, (func, interval) in enumerate(func_and_domains):
+                if not interval.contains(mid) or sympy.sympify(func.den).subs(x, mid) == 0:
+                    continue
+                if ref == -1 or comparator(func.at(mid), winner.at(mid)):
+                    winner, ref = func, i
+            if best_bound:
+                prev, previous_domain, previous_ref = best_bound[-1]
+                same = (previous_ref == ref if track_dependencies else
+                        previous_ref == ref or (previous_ref != -1 and ref != -1 and prev == winner))
+                if (same and previous_domain.x1 == cell.x0 and
+                        (previous_domain.include_upper or cell.include_lower)):
+                    previous_domain.x1 = cell.x1
+                    previous_domain.include_upper = cell.include_upper
+                    continue
+            best_bound.append((winner, cell, ref))
 
         if track_dependencies:
             return best_bound
-        else:
-            return [(b[0], b[1]) for b in best_bound]
+        return [(f, interval) for f, interval, _ in best_bound]
 
     # Given a list of (RationalFunction, Interval) tuples, compute their (piecewise) minimum.
     # The result is returned as a list of (RationalFunction, Interval, Integer) tuples, where
     # the last element indicates the index of the RationalFunction piece in the original
     # list of functions.
-    # If a function is not defined on an interval, it is treated as -infinity.
+    # If a function is not defined on an interval, it is treated as +infinity.
     def min(func_and_domains: list, domain: Interval, track_dependencies=True) -> list:
         if not isinstance(func_and_domains, list):
             raise ValueError("Parameter piecewise_funcs must be of type list")
@@ -877,7 +878,7 @@ class RationalFunction:
             raise ValueError("Parameter domain must be of type Interval")
 
         return RationalFunction._compute_optimal(
-            func_and_domains, domain, lambda x, y: x < y, 1000000, track_dependencies)
+            func_and_domains, domain, lambda x, y: x < y, sympy.oo, track_dependencies)
 
     # Given a list of (RationalFunction, Interval) tuples, compute their maximum. The
     # result is returned as a list of (RationalFunction, Interval, Integer) tuples, where
@@ -890,7 +891,7 @@ class RationalFunction:
         if not isinstance(domain, Interval):
             raise ValueError("Parameter domain must be of type Interval")
         return RationalFunction._compute_optimal(
-            func_and_domains, domain, lambda x, y: x > y, -1000000, track_dependencies)
+            func_and_domains, domain, lambda x, y: x > y, -sympy.oo, track_dependencies)
 
     # ------------------------------------------------------------------
 

--- a/blueprint/src/python/tests/test_all.py
+++ b/blueprint/src/python/tests/test_all.py
@@ -40,4 +40,6 @@ import test_ep_to_zd
 
 print("All ep_to_zd regression test cases passed.")
 
+import test_rational_envelope_regression
+
 print("All test cases passed.")

--- a/blueprint/src/python/tests/test_rational_envelope_regression.py
+++ b/blueprint/src/python/tests/test_rational_envelope_regression.py
@@ -1,0 +1,29 @@
+from functions import RationalFunction as R, Interval
+from fractions import Fraction as F
+import sympy
+
+def run_regressions():
+    domain = Interval(-2, 2, True, True)
+    for method, value in ((R.min, 2000000), (R.max, -2000000)):
+        result = method([(R([value]), domain)], domain)
+        assert len(result) == 1 and result[0][2] == 0
+        assert result[0][1] == domain and result[0][0].at(0) == value
+    for method, choose, default in ((R.min, min, sympy.oo), (R.max, max, -sympy.oo)):
+        inputs = [(R([1], [1, 0]), Interval(-2, 2, False, True)),
+                  (R([0]), Interval(-1, 1, True, False)),
+                  (R([-3]), Interval(2, 2, True, True))]
+        pieces = method(inputs, domain)
+        for x in [F(k, 4) for k in range(-8, 9)]:
+            active = [(f, i) for f, cell, i in pieces if cell.contains(x)]
+            assert len(active) == 1
+            values = [f.at(x) for f, cell in inputs
+                      if cell.contains(x) and sympy.sympify(f.den).subs(R.x, x) != 0]
+            expected = choose(values) if values else default
+            assert active[0][0].at(x) == expected
+            assert (active[0][1] == -1) == (not values)
+        assert all(len(item) == 2 for item in method(inputs, domain, False))
+    singleton = Interval(1, 1, True, True)
+    assert R.min([(R([7]), singleton)], singleton)[0][1] == singleton
+    assert R.min([], Interval(1, 1)) == []
+
+run_regressions()


### PR DESCRIPTION
The minimum of the constant 2,000,000 is currently returned as 1,000,000 with dependency -1; maxima have the symmetric failure. The envelope sweep also rebuilds every piece as `[a,b)`, losing closed upper endpoints, adding excluded lower endpoints, and dropping singleton domains. A pole can change the winner without an intersection.

Partition the requested domain at input endpoints, pairwise intersections, and denominator roots; select winners on separate singleton and open cells. Use actual positive/negative infinity only where no candidate is defined, skip poles, and merge adjacent cells while preserving endpoint flags and dependency tracking. Regressions check large bounds, poles, gaps, endpoint-only bounds, empty/singleton domains, and both dependency modes.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
