### PR TITLE
Exclude poles when finding rational roots and intersections

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -973,21 +973,21 @@ class RationalFunction:
     # Computes all the intersection points between this RationalFunction and another
     # on an interval
     def intersections(self, other, interval):
-        # Intersections of P/Q = R/S when PS - RQ = 0
-        f = self.num * other.den - self.den * other.num
-        if not f.is_constant():
-            return [
-                SympyHelper.to_frac(r)
-                for r in sympy.real_roots(f)
+        # Cross multiplication supplies candidates, but poles are not intersections.
+        numerator = sympy.sympify(self.num * other.den - self.den * other.num)
+        if numerator.is_constant():
+            return []
+        return [SympyHelper.to_frac(r) for r in sympy.real_roots(numerator)
                 if interval.contains(r)
-            ]
-        return []
+                and sympy.sympify(self.den).subs(self.x, r) != 0
+                and sympy.sympify(other.den).subs(self.x, r) != 0]
 
     def roots(self, interval):
-        f = self.num / self.den
-        if f.is_constant():
+        numerator = sympy.sympify(self.num)
+        if numerator.is_constant():
             return []
-        return [r for r in sympy.real_roots(f) if interval.contains(r)]
+        return [r for r in sympy.real_roots(numerator)
+                if interval.contains(r) and sympy.sympify(self.den).subs(self.x, r) != 0]
 
     # Compute the maximum over an interval of type Interval
     def maximise(self, interval):

--- a/blueprint/src/python/tests/test_all.py
+++ b/blueprint/src/python/tests/test_all.py
@@ -29,6 +29,7 @@ import test_polytope
 print("All Polytope test cases passed.")
 
 import test_rationalfunction
+import test_rational_roots_regression
 
 print("All RationalFunction test cases passed.")
 

--- a/blueprint/src/python/tests/test_rational_roots_regression.py
+++ b/blueprint/src/python/tests/test_rational_roots_regression.py
@@ -1,0 +1,14 @@
+from functions import RationalFunction as R, Interval
+
+def run_regressions():
+    interval = Interval(-3, 3, True, True)
+    assert R([1, -1], [1, 2]).roots(interval) == [1]
+    assert R([1, -1], [1, -1]).roots(interval) == []
+    assert R([7]).roots(interval) == []
+    assert R([1, -1], [1, 2]).roots(Interval(1, 2, False, True)) == []
+    # Cross multiplication vanishes at the shared pole, where neither exists.
+    assert R([1], [1, 0]).intersections(R([2], [1, 0]), interval) == []
+    assert R([1], [1, 0]).intersections(R([1]), interval) == [1]
+    assert R([1]).intersections(R([2]), interval) == []
+
+run_regressions()


### PR DESCRIPTION
`RationalFunction([1, -1], [1, 2]).roots(...)` raises a polynomial error because the implementation passes the quotient to `real_roots`. Cross multiplication also incorrectly reports a shared pole as an intersection: `1/x` and `2/x` currently "intersect" at zero.

Find candidate roots from the numerator polynomial and exclude zeros of the denominator. Apply the same domain check to both denominators after cross multiplication for intersections, and sympify constant polynomials before checking them. Regressions cover genuine zeros/intersections, canceled numerator factors, shared poles, constants, and excluded interval endpoints.

Validation: `python tests/test_all.py` (Python 3.12, pycddlib 2.1.8.post1). The added regression module fails on unchanged upstream and passes with this patch.

This defect was reproduced during a code audit; no existing issue report is claimed.
