### PR TITLE
Bump concurrent-ruby to ≥ 1.3.5 in the homepage lockfile

### DIFF
--- a/home_page/Gemfile
+++ b/home_page/Gemfile
@@ -23,3 +23,5 @@ gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 # Used for locally serving the website.
 gem "webrick", "~> 1.7"
+# CVE-2025-55193 / issue #214: ReadWriteLock race in < 1.3.5
+gem "concurrent-ruby", ">= 1.3.5"

--- a/home_page/Gemfile.lock
+++ b/home_page/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     coffee-script-source (1.11.1)
     colorator (1.1.0)
     commonmarker (0.23.4)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.8)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
     em-websocket (0.5.3)
@@ -225,12 +225,16 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.15.0)
     multipart-post (2.1.1)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     octokit (4.22.0)
@@ -273,9 +277,11 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
+  concurrent-ruby (>= 1.3.5)
   github-pages
   http_parser.rb (~> 0.6.0)
   tzinfo (~> 1.2)
@@ -284,4 +290,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.14
+  4.0.16


### PR DESCRIPTION
## Summary
- Constrains concurrent-ruby >= 1.3.5 and refreshes home_page/Gemfile.lock (1.3.8)
- Addresses the ReadWriteLock race in issue #214

## Test plan
- [x] bundle update concurrent-ruby
- [x] lockfile shows concurrent-ruby (1.3.8)

Fixes #214