### PR TITLE
Keep exponent-pair and mu hull caches independent

### DIFF
--- a/blueprint/src/python/bound_mu.py
+++ b/blueprint/src/python/bound_mu.py
@@ -220,7 +220,7 @@ def get_bounds(hypothesis_set):
 def compute_convex_hull(bounds, hypothesis_set):
     conv = ConvexHull(np.array([[b.data.sigma, b.data.mu] for b in bounds]))
     vertices = [bounds[v] for v in conv.vertices]
-    hypothesis_set.data["convex_hull"] = vertices
+    hypothesis_set.data['mu_convex_hull'] = vertices
     hypothesis_set.data_valid = True
 
 
@@ -236,7 +236,7 @@ def best_mu_bound(sigma, hypothesis_set):
 
     # Computed convex hull is stored within `hypothesis_list` the first time
     # to avoid repeatedly computing it for multiple values of sigma.
-    if not hypothesis_set.data_valid or "convex_hull" not in hypothesis_set.data:
+    if not hypothesis_set.data_valid or 'mu_convex_hull' not in hypothesis_set.data:
         # Generate set of bounds on mu implied by hypothesis set
         bounds = get_bounds(hypothesis_set)
         # The convex hull package requires us to provide at least 3 points, while some
@@ -246,7 +246,7 @@ def best_mu_bound(sigma, hypothesis_set):
         compute_convex_hull(pts, hypothesis_set)
 
     # The vertices are guaranteed to be in counterclockwise order for 2D hulls
-    verts = hypothesis_set.data["convex_hull"]
+    verts = hypothesis_set.data['mu_convex_hull']
     for i in range(len(verts)):
         b1 = verts[i]
         b2 = verts[(i + 1) % len(verts)]
@@ -293,12 +293,12 @@ def best_mu_bound_piecewise(
 
     # Computed convex hull is stored within `hypothesis_set` the first time
     # to avoid repeatedly computing it for multiple values of sigma.
-    if not hypothesis_set.data_valid or "convex_hull" not in hypothesis_set.data:
+    if not hypothesis_set.data_valid or 'mu_convex_hull' not in hypothesis_set.data:
         bounds = get_bounds(hypothesis_set)
         compute_convex_hull(bounds, hypothesis_set)
 
     # The vertices are guaranteed to be in counterclockwise order for 2D hulls
-    verts = hypothesis_set.data["convex_hull"]
+    verts = hypothesis_set.data['mu_convex_hull']
     mu_bounds = []
     for i in range(len(verts)):
         b1 = verts[i].data

--- a/blueprint/src/python/exponent_pair.py
+++ b/blueprint/src/python/exponent_pair.py
@@ -141,16 +141,16 @@ def compute_convex_hull(hypothesis_set: Hypothesis_Set) -> ConvexHull:
 
     # Computed convex hull is stored within `hypothesis_list` the first time
     # to avoid repeatedly computing it for multiple values of sigma.
-    if not hypothesis_set.data_valid or "convex_hull" not in hypothesis_set.data:
+    if not hypothesis_set.data_valid or 'exponent_pair_convex_hull' not in hypothesis_set.data:
         if len(pairs) < 3:
-            hypothesis_set.data["convex_hull"] = list(pairs)
+            hypothesis_set.data['exponent_pair_convex_hull'] = list(pairs)
         else:
             conv = ConvexHull(np.array([[p.data.k, p.data.l] for p in pairs]))
             vertices = [pairs[v] for v in conv.vertices]
-            hypothesis_set.data["convex_hull"] = vertices
+            hypothesis_set.data['exponent_pair_convex_hull'] = vertices
             hypothesis_set.data_valid = True
 
-    return hypothesis_set.data["convex_hull"]
+    return hypothesis_set.data['exponent_pair_convex_hull']
 
 def beta_bounds_to_exponent_pairs(
         hypothesis_set: Hypothesis_Set,

--- a/blueprint/src/python/hypotheses.py
+++ b/blueprint/src/python/hypotheses.py
@@ -162,10 +162,10 @@ class Hypothesis:
 class Hypothesis_Set:
     def __init__(self, hypotheses=None):
         self.hypotheses = set()
-        if hypotheses is not None:
-            self.add_hypotheses(hypotheses)
         self.data = {}
         self.data_valid = False  # set to false whenever data needs to be recomputed
+        if hypotheses is not None:
+            self.add_hypotheses(hypotheses)
 
     def __repr__(self):
         return f'Set of {len(self.hypotheses)} hypotheses: [{",".join(h.name for h in self.hypotheses)}]'
@@ -173,7 +173,7 @@ class Hypothesis_Set:
     # Shallow copy, the hypothesis objects are not cloned
     def __copy__(self):
         copy = Hypothesis_Set(self.hypotheses)
-        copy.data = self.data
+        copy.data = self.data.copy()
         copy.data_valid = self.data_valid
         return copy
 
@@ -203,6 +203,7 @@ class Hypothesis_Set:
     def add_hypothesis(self, hypothesis, invalidate_data=True):
         self.hypotheses.add(hypothesis)
         if invalidate_data:
+            self.data.clear()
             self.data_valid = False
 
     # Adds a set or list of hypotheses, an individual hypothesis, or a Hypothesis_Set
@@ -216,6 +217,7 @@ class Hypothesis_Set:
         else:
             self.hypotheses.update(new_hypotheses)
             if invalidate_data:
+                self.data.clear()
                 self.data_valid = False
 
     # return all hypotheses of a given type, and (optionally) up to a given year.  Note: is now returning a Hypothesis_Set rather than a list

--- a/blueprint/src/python/tests/test_all.py
+++ b/blueprint/src/python/tests/test_all.py
@@ -12,6 +12,8 @@ import test_affine2
 
 print("All Affine2 test cases passed.")
 
+import test_hypothesis_cache
+
 import test_exppair
 
 print("All exponent pair test cases passed.")

--- a/blueprint/src/python/tests/test_hypothesis_cache.py
+++ b/blueprint/src/python/tests/test_hypothesis_cache.py
@@ -1,0 +1,52 @@
+import copy
+from fractions import Fraction as F
+
+import bound_mu as mu
+import exponent_pair as ep
+from hypotheses import Hypothesis_Set
+from reference import Reference
+
+
+def hypotheses():
+    return Hypothesis_Set([
+        ep.trivial_exp_pair,
+        ep.literature_exp_pair(F(1, 2), F(1, 2), Reference.make("Test", 2024)),
+        ep.literature_exp_pair(F(1, 6), F(2, 3), Reference.make("Test", 2024)),
+    ])
+
+
+def test_both_hulls_can_be_computed_in_either_order():
+    for mu_first in (False, True):
+        h = hypotheses()
+        if mu_first:
+            assert mu.best_mu_bound(F(1, 2), h).data.mu == F(1, 6)
+        vertices = ep.compute_convex_hull(h)
+        assert all(isinstance(v.data, ep.Exp_pair) for v in vertices)
+        assert mu.best_mu_bound(F(1, 2), h).data.mu == F(1, 6)
+        assert ep.compute_convex_hull(h) == vertices
+
+
+def test_mutation_invalidates_both_hulls():
+    for add in (lambda h, x: h.add_hypothesis(x),
+                lambda h, x: h.add_hypotheses([x])):
+        h = hypotheses()
+        ep.compute_convex_hull(h)
+        mu.best_mu_bound(F(1, 2), h)
+        stronger = ep.literature_exp_pair(F(0), F(1, 2), Reference.make("Test", 2024))
+        add(h, stronger)
+        assert stronger in ep.compute_convex_hull(h)
+        assert mu.best_mu_bound(F(1, 2), h).data.mu == 0
+
+
+def test_recomputing_copy_does_not_corrupt_original_cache():
+    original = hypotheses()
+    assert mu.best_mu_bound(F(1, 2), original).data.mu == F(1, 6)
+    derived = copy.copy(original)
+    derived.add_hypothesis(mu.classical_bound_mu(F(1, 2), 0))
+    assert mu.best_mu_bound(F(1, 2), derived).data.mu == 0
+    assert mu.best_mu_bound(F(1, 2), original).data.mu == F(1, 6)
+
+
+test_both_hulls_can_be_computed_in_either_order()
+test_mutation_invalidates_both_hulls()
+test_recomputing_copy_does_not_corrupt_original_cache()


### PR DESCRIPTION
Computing an exponent-pair hull and then a mu bound on the same hypothesis set currently reads incompatible vertices from the shared `convex_hull` cache and raises `AttributeError`. A shallow copy also shares that cache dictionary, so recomputing bounds on the copy can change the original's answers.

Give the two hulls separate keys, clear all cached results when hypotheses change, and copy the cache dictionary when copying a set. Regression tests cover both query orders, mutation through both add methods, and recomputation on a copied set.

Validation: reproduced the mixed-query failure on upstream main; focused regression tests and `python tests/test_all.py` pass with Python 3.11 and pycddlib 2.1.8.post1.
