### PR TITLE
Preserve open endpoints when reflecting beta bounds

### DIFF
--- a/blueprint/src/python/bound_beta.py
+++ b/blueprint/src/python/bound_beta.py
@@ -118,7 +118,10 @@ def apply_reflection_beta(bounds: list[Hypothesis]) -> list[Hypothesis]:
         new_x1 = 1 - x0
 
         # Step 3: Build the new Affine bound with reflected interval
-        new_affine = Affine(new_m, new_c, Interval(new_x0, new_x1, True, True))
+        new_affine = Affine(
+            new_m, new_c,
+            Interval(new_x0, new_x1, p.domain.include_upper, p.domain.include_lower),
+        )
 
         # Step 4: Wrap in a derived Hypothesis, preserving the dependency chain
         new_hyp = derived_bound_beta(

--- a/blueprint/src/python/tests/test_all.py
+++ b/blueprint/src/python/tests/test_all.py
@@ -12,6 +12,8 @@ import test_affine2
 
 print("All Affine2 test cases passed.")
 
+import test_beta_reflection
+
 import test_exppair
 
 print("All exponent pair test cases passed.")

--- a/blueprint/src/python/tests/test_beta_reflection.py
+++ b/blueprint/src/python/tests/test_beta_reflection.py
@@ -1,0 +1,23 @@
+from fractions import Fraction as F
+from bound_beta import apply_reflection_beta, classical_bound_beta
+from functions import Affine, Interval
+
+
+def test_reflection_preserves_domain_membership():
+    for lower in (False, True):
+        for upper in (False, True):
+            source = classical_bound_beta(Affine(F(2, 3), F(1, 7),
+                Interval(F(1, 4), F(1, 2), lower, upper)))
+            result = apply_reflection_beta([source])[0]
+            reflected = result.data.bound
+            assert reflected.domain == Interval(F(1, 2), F(3, 4), upper, lower)
+            assert result.dependencies == {source}
+            for x in (F(1, 2), F(5, 8), F(3, 4)):
+                assert reflected.domain.contains(x) == source.data.bound.domain.contains(1 - x)
+                if reflected.domain.contains(x):
+                    assert reflected.at(x) == x - F(1, 2) + source.data.bound.at(1 - x)
+            twice = apply_reflection_beta([result])[0].data.bound
+            assert twice == source.data.bound
+
+
+test_reflection_preserves_domain_membership()


### PR DESCRIPTION
Reflecting a beta bound currently makes both endpoints closed, including endpoints where the source hypothesis gives no bound. For example, a bound on `[1/4, 1/2)` must reflect to `(1/2, 3/4]`.

Swap the source interval's endpoint inclusion flags with its endpoints. Tests check all four open/closed combinations, transformed values, dependencies, and that reflecting twice restores the original bound.

Validation: the new regression fails on upstream main; focused tests and `python tests/test_all.py` pass.
