### PR TITLE
Construct exponent-pair proofs from segments and either triangle orientation

### DIFF
--- a/blueprint/src/python/exponent_pair.py
+++ b/blueprint/src/python/exponent_pair.py
@@ -256,10 +256,17 @@ def beta_bounds_to_exponent_pairs(
 # Returns whether point p lies in the triangle with vertices a, b, c (all points
 # two-dimensional)
 def in_triangle(a, b, c, p):
-     d = ((b[1] - c[1])*(a[0] - c[0]) + (c[0] - b[0])*(a[1] - c[1]))
-     x = ((b[1] - c[1])*(p[0] - c[0]) + (c[0] - b[0])*(p[1] - c[1]))
-     y = ((c[1] - a[1])*(p[0] - c[0]) + (a[0] - c[0])*(p[1] - c[1]))
-     return 0 <= x and x <= d and 0 <= y and y <= d and x + y <= d
+    def cross(u, v, w):
+        return (v[0] - u[0]) * (w[1] - u[1]) - (v[1] - u[1]) * (w[0] - u[0])
+
+    area = cross(a, b, c)
+    if area == 0:
+        # Collinearity alone describes the whole line, not the triangle's segment.
+        return (cross(a, b, p) == 0 and cross(a, c, p) == 0
+                and min(a[0], b[0], c[0]) <= p[0] <= max(a[0], b[0], c[0])
+                and min(a[1], b[1], c[1]) <= p[1] <= max(a[1], b[1], c[1]))
+    signs = [cross(a, b, p), cross(b, c, p), cross(c, a, p)]
+    return all(x >= 0 for x in signs) or all(x <= 0 for x in signs)
 
 def construct_proof(
         k: frac,
@@ -316,6 +323,13 @@ def construct_proof(
     # The exponent pair is contained in the convex hull - if reduce_dependencies,
     # is set to false, return the entire hull as dependencies
     if not reduce_dependencies:
+        proof = "Follows from convexity and the exponent pairs " + ", ".join(
+            f"({v.data.k}, {v.data.l})" for v in verts)
+        return derived_exp_pair(k, l, proof, set(verts))
+
+    # A segment hull has no triangle to search. Its two endpoints already
+    # certify every point in the hull, including when dependency reduction is on.
+    if len(verts) <= 2:
         proof = "Follows from convexity and the exponent pairs " + ", ".join(
             f"({v.data.k}, {v.data.l})" for v in verts)
         return derived_exp_pair(k, l, proof, set(verts))

--- a/blueprint/src/python/tests/test_exppair.py
+++ b/blueprint/src/python/tests/test_exppair.py
@@ -21,3 +21,33 @@ def run_exp_pair_transform_tests():
     assert AE.data.k == frac(1, 14) and AE.data.l == frac(11, 14)
 
 run_exp_pair_transform_tests()
+
+
+def test_prove_convex_combination_of_two_pairs():
+    left = trivial_exp_pair
+    right = literature_exp_pair(frac(1, 2), frac(1, 2), Reference.make("Test", 2024))
+    hypotheses = Hypothesis_Set([left, right])
+    for deep_search in (False, True):
+        result = construct_proof(frac(1, 4), frac(3, 4), hypotheses,
+                                     reduce_dependencies=True, deep_search=deep_search)
+        assert result.data == Exp_pair(frac(1, 4), frac(3, 4))
+        assert result.dependencies == {left, right}
+    assert construct_proof(frac(1, 4), frac(1, 2), hypotheses) is None
+    assert construct_proof(0, 1, Hypothesis_Set([left])) is left
+
+
+test_prove_convex_combination_of_two_pairs()
+
+
+def test_triangle_containment_is_independent_of_vertex_order():
+    import itertools
+    for vertices in itertools.permutations([(0, 0), (1, 0), (0, 1)]):
+        assert in_triangle(*vertices, (frac(1, 4), frac(1, 4)))
+        assert in_triangle(*vertices, (frac(1, 2), frac(1, 2)))
+        assert not in_triangle(*vertices, (1, 1))
+    assert in_triangle((0, 0), (1, 0), (2, 0), (frac(1, 2), 0))
+    assert not in_triangle((0, 0), (1, 0), (2, 0), (3, 0))
+    assert not in_triangle((0, 0), (0, 0), (0, 0), (1, 1))
+
+
+test_triangle_containment_is_independent_of_vertex_order()


### PR DESCRIPTION
Constructing a proof of `(1/4, 3/4)` from `(0, 1)` and `(1/2, 1/2)` crashes because dependency reduction searches for a three-vertex triangle in a two-vertex hull. Use the segment endpoints directly in this case.

The same proof search also uses an orientation-sensitive triangle predicate, and its degenerate case accepts points beyond the segment. Check signed cross products in either orientation and bound collinear points by the vertices. Tests cover the two-pair proof, all triangle vertex permutations, edges, and degenerate triangles.

Validation: reproduced the two-pair crash on upstream main; focused tests and `python tests/test_all.py` pass.
