### PR TITLE
Compute collinear exponent-pair hulls without Qhull errors

### DIFF
--- a/blueprint/src/python/exponent_pair.py
+++ b/blueprint/src/python/exponent_pair.py
@@ -69,6 +69,20 @@ exponent_pair_conjecture = Hypothesis(
 
 ###############################################################################
 
+def _convex_hull_vertices(pairs):
+    """Return hull vertices, including point and segment hulls unsupported by Qhull."""
+    pairs = list({(p.data.k, p.data.l): p for p in pairs}.values())
+    if len(pairs) <= 2:
+        return pairs
+    ordered = sorted(pairs, key=lambda p: (p.data.k, p.data.l))
+    a, b = ordered[0].data, ordered[-1].data
+    if all((p.data.k - a.k) * (b.l - a.l) ==
+           (p.data.l - a.l) * (b.k - a.k) for p in ordered):
+        return [ordered[0], ordered[-1]]
+    conv = ConvexHull(np.array([[p.data.k, p.data.l] for p in pairs]))
+    return [pairs[v] for v in conv.vertices]
+
+
 def compute_exp_pairs(
         hypothesis_set: Hypothesis_Set,
         search_depth: int = 5,
@@ -112,9 +126,7 @@ def compute_exp_pairs(
         if prune:
             if len(pairs) < 3:
                 continue  # Don't prune if set is too small
-            pairs = [p for p in pairs.values()]
-            conv = ConvexHull(np.array([[p.data.k, p.data.l] for p in pairs]))
-            verts = [pairs[v] for v in conv.vertices]
+            verts = _convex_hull_vertices(pairs.values())
             pairs = {(p.data.k, p.data.l): p for p in verts}
 
     return [p for p in pairs.values()]
@@ -142,13 +154,8 @@ def compute_convex_hull(hypothesis_set: Hypothesis_Set) -> ConvexHull:
     # Computed convex hull is stored within `hypothesis_list` the first time
     # to avoid repeatedly computing it for multiple values of sigma.
     if not hypothesis_set.data_valid or "convex_hull" not in hypothesis_set.data:
-        if len(pairs) < 3:
-            hypothesis_set.data["convex_hull"] = list(pairs)
-        else:
-            conv = ConvexHull(np.array([[p.data.k, p.data.l] for p in pairs]))
-            vertices = [pairs[v] for v in conv.vertices]
-            hypothesis_set.data["convex_hull"] = vertices
-            hypothesis_set.data_valid = True
+        hypothesis_set.data["convex_hull"] = _convex_hull_vertices(pairs)
+        hypothesis_set.data_valid = True
 
     return hypothesis_set.data["convex_hull"]
 

--- a/blueprint/src/python/tests/test_exppair.py
+++ b/blueprint/src/python/tests/test_exppair.py
@@ -21,3 +21,21 @@ def run_exp_pair_transform_tests():
     assert AE.data.k == frac(1, 14) and AE.data.l == frac(11, 14)
 
 run_exp_pair_transform_tests()
+
+
+def test_collinear_and_duplicate_exponent_pair_hulls():
+    for coordinates in ([(0, 1), (frac(1, 4), frac(3, 4)), (frac(1, 2), frac(1, 2))],
+                        [(0, 1), (0, 1), (0, 1)],
+                        [(0, frac(1, 2)), (0, frac(3, 4)), (0, 1)]):
+        pairs = [literature_exp_pair(k, l, Reference.make(str(i), 2024))
+                 for i, (k, l) in enumerate(coordinates)]
+        hypotheses = Hypothesis_Set(pairs)
+        expected = {min(coordinates), max(coordinates)}
+        hull = compute_convex_hull(hypotheses)
+        assert {(p.data.k, p.data.l) for p in hull} == expected
+        expanded = compute_exp_pairs(hypotheses, search_depth=2, prune=True)
+        # Duplicate coordinates are collapsed even when no pruning is needed.
+        assert {(p.data.k, p.data.l) for p in expanded} == expected
+
+
+test_collinear_and_duplicate_exponent_pair_hulls()


### PR DESCRIPTION
A hypothesis set containing the valid collinear pairs `(0, 1)`, `(1/4, 3/4)`, and `(1/2, 1/2)` crashes in Qhull, both when obtaining its hull and when pruning transformed pairs.

Detect point and segment hulls using the original coordinates before invoking Qhull. Keep the segment endpoints, deduplicate coordinates, and retain the existing Qhull path for full-dimensional inputs. Tests cover sloping and vertical segments and coincident pairs through both public paths.

Validation: reproduced Qhull's flat-simplex error on upstream main; focused tests and `python tests/test_all.py` pass.
