### PR TITLE
Handle unlabelled equal affine functions in minimum calculations

### DIFF
--- a/blueprint/src/python/functions.py
+++ b/blueprint/src/python/functions.py
@@ -407,7 +407,11 @@ class Affine2:
             # If two functions are identical, then we add the one with a smaller
             # label. This is to establish a replicable order of functions.
             if all(self.a[i] == f.a[i] for i in range(len(self.a))):
-                fn = self if self.label < f.label else f
+                # Labels are optional; use the labelled piece when only one
+                # is labelled, and keep the left piece when neither is.
+                fn = self
+                if f.label is not None and (self.label is None or f.label < self.label):
+                    fn = f
                 pieces.append(Affine2(fn.a, domain, fn.label))  # Shallow copying
                 continue
 

--- a/blueprint/src/python/tests/test_affine2.py
+++ b/blueprint/src/python/tests/test_affine2.py
@@ -33,3 +33,17 @@ def test_edge_case():
             assert m.at([x, y]) == min(f[0] + f[1] * x + f[2] * y for f in fns)
 
 test_edge_case()
+
+
+def test_equal_affine_functions_with_optional_labels():
+    domain = Polytope.rect((0, 1), (0, 1))
+    for left, right, expected in [(None, None, None), (None, 2, 2), (2, None, 2), (2, 1, 1)]:
+        a = Affine2([1, 2, 3], domain, left)
+        b = Affine2([1, 2, 3], domain, right)
+        pieces = a.min_with([b])
+        assert len(pieces) == 1
+        assert pieces[0].label == expected
+        assert pieces[0].at([frac(1, 2), frac(1, 2)]) == frac(7, 2)
+
+
+test_equal_affine_functions_with_optional_labels()


### PR DESCRIPTION
Taking the minimum of two identical `Affine2` functions constructed with their default labels raises `TypeError` because it compares `None < None`.

Handle the optional labels explicitly: retain the left piece if both are unlabelled, use the labelled piece when only one is labelled, and retain the existing smaller-label choice when both are labelled. Tests exercise all four cases and check the resulting affine value.

Validation: reproduced the `NoneType` comparison on upstream main; focused affine tests and `python tests/test_all.py` pass.
